### PR TITLE
Add basic module-Jackson functionality

### DIFF
--- a/src/main/java/unibook/model/module/Module.java
+++ b/src/main/java/unibook/model/module/Module.java
@@ -4,16 +4,20 @@ import static unibook.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import unibook.model.person.Professor;
 import unibook.model.person.Student;
-
-
 /**
  * Represents a Module in the UniBook.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
+//Todo: add support for students and professors for JSON/storage
+@JsonIgnoreProperties(value = {"students", "professors"})
 public class Module {
 
     // Identity fields
@@ -25,6 +29,17 @@ public class Module {
     private final ObservableList<Professor> professors;
     private final ObservableList<Student> students;
 
+    /**
+     * Default constructor taking in String for Jackson
+     */
+    @JsonCreator
+    public Module(@JsonProperty("moduleName") String moduleName, @JsonProperty("moduleCode") String moduleCode) {
+        requireAllNonNull(moduleName, moduleCode);
+        this.moduleName = new ModuleName(moduleName);
+        this.moduleCode = new ModuleCode(moduleCode);
+        this.professors = FXCollections.observableArrayList();
+        this.students = FXCollections.observableArrayList();
+    }
     /**
      * Constructor for a Module, assuming no students and no professor initially.
      * can add if necessary.

--- a/src/main/java/unibook/model/util/SampleDataUtil.java
+++ b/src/main/java/unibook/model/util/SampleDataUtil.java
@@ -22,24 +22,28 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                getTagSet("friends"), getModuleSet("CS2103")),
+                getTagSet("friends"), getModuleSet("CS2106")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 getTagSet("colleagues", "friends"), getModuleSet("CS2103")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 getTagSet("neighbours"), getModuleSet("CS2103")),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                getTagSet("family"), getModuleSet("CS2103")),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                getTagSet("classmates"), getModuleSet("CS2103")),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                getTagSet("colleagues"), getModuleSet("CS2103"))
         };
+    }
+
+    public static Module[] getSampleModules() {
+        Module testModule1 = new Module(new ModuleName("Software Engineering"), new ModuleCode("CS2103"));
+        Module testModule2 = new Module(new ModuleName("Introduction to Operating Systems"), new ModuleCode("CS2106"));
+
+        return new Module[] {testModule1, testModule2};
     }
 
     public static ReadOnlyUniBook getSampleUniBook() {
         UniBook sampleAb = new UniBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
+        }
+        for (Module mod : getSampleModules()) {
+            sampleAb.addModule(mod);
         }
         return sampleAb;
     }

--- a/src/main/java/unibook/model/util/SampleDataUtil.java
+++ b/src/main/java/unibook/model/util/SampleDataUtil.java
@@ -1,6 +1,7 @@
 package unibook.model.util;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -13,6 +14,7 @@ import unibook.model.person.Email;
 import unibook.model.person.Name;
 import unibook.model.person.Person;
 import unibook.model.person.Phone;
+import unibook.model.person.Student;
 import unibook.model.tag.Tag;
 
 /**
@@ -39,12 +41,41 @@ public class SampleDataUtil {
 
     public static ReadOnlyUniBook getSampleUniBook() {
         UniBook sampleAb = new UniBook();
-        for (Person samplePerson : getSamplePersons()) {
-            sampleAb.addPerson(samplePerson);
-        }
-        for (Module mod : getSampleModules()) {
-            sampleAb.addModule(mod);
-        }
+
+        //modules[0] == cs2103, modules[1] == cs2106
+        Module[] modules = getSampleModules();
+
+        //Initialising test module sets to pass into Student constructor
+        Set<Module> testModuleSet1 = new HashSet<>();
+        Set<Module> testModuleSet2 = new HashSet<>();
+        Set<Module> testModuleSet3 = new HashSet<>();
+
+        //Test module sets for s1, s2, s3 respectively
+        testModuleSet1.add(modules[1]);
+        testModuleSet2.add(modules[0]);
+        testModuleSet3.add(modules[0]);
+
+        //Initialising student objects
+        Student s1 = new Student(new Name("Alex Yeoh"),
+                new Phone("87438807"), new Email("alexyeoh@example.com"),
+                getTagSet("friends"), testModuleSet1);
+        Student s2 = new Student(new Name("Bernice Yu"),
+                new Phone("99272758"), new Email("berniceyu@example.com"),
+                getTagSet("colleagues", "friends"), testModuleSet2);
+        Student s3 = new Student(new Name("Charlotte Oliveiro"),
+                new Phone("93210283"), new Email("charlotte@example.com"),
+                getTagSet("neighbours"), testModuleSet3);
+
+        //Add students to module's student list
+        modules[1].addStudent(s1);
+        modules[0].addStudent(s2);
+        modules[0].addStudent(s3);
+
+        //Add students to sample Unibook
+        sampleAb.addPerson(s1);
+        sampleAb.addPerson(s2);
+        sampleAb.addPerson(s3);
+
         return sampleAb;
     }
 

--- a/src/main/java/unibook/model/util/SampleDataUtil.java
+++ b/src/main/java/unibook/model/util/SampleDataUtil.java
@@ -76,6 +76,9 @@ public class SampleDataUtil {
         sampleAb.addPerson(s2);
         sampleAb.addPerson(s3);
 
+        //Add modules to sample Unibook
+        sampleAb.addModule(modules[0]);
+        sampleAb.addModule(modules[1]);
         return sampleAb;
     }
 

--- a/src/main/java/unibook/storage/JsonAdaptedModule.java
+++ b/src/main/java/unibook/storage/JsonAdaptedModule.java
@@ -1,0 +1,59 @@
+package unibook.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import unibook.commons.exceptions.IllegalValueException;
+import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
+import unibook.model.module.ModuleName;
+import unibook.model.person.Name;
+import unibook.model.person.Phone;
+
+
+
+/**
+ * Jackson-friendly version of {@link Module}.
+ */
+class JsonAdaptedModule {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+
+    private final String moduleName;
+    private final String moduleCode;
+    //todo: add support for list of students/professors in module
+
+
+    @JsonCreator
+    public JsonAdaptedModule(@JsonProperty("moduleName") String moduleName,
+                             @JsonProperty("moduleCode") String moduleCode) {
+        this.moduleName = moduleName;
+        this.moduleCode = moduleCode;
+    }
+
+    @JsonCreator
+    public JsonAdaptedModule(Module source) {
+        this.moduleName = source.getModuleName().toString();
+        this.moduleCode = source.getModuleCode().toString();
+    }
+
+
+    /**
+     * Converts this Jackson-friendly adapted person object into the model's {@code Module} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public Module toModelType() throws IllegalValueException {
+
+        if (moduleName == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (moduleCode == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
+        }
+
+        //Todo add support for existing list and student/professor list functionality
+        return new Module(new ModuleName(moduleName), new ModuleCode(moduleCode));
+    }
+
+}

--- a/src/main/java/unibook/storage/JsonSerializableUniBook.java
+++ b/src/main/java/unibook/storage/JsonSerializableUniBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import unibook.commons.exceptions.IllegalValueException;
 import unibook.model.ReadOnlyUniBook;
 import unibook.model.UniBook;
+import unibook.model.module.Module;
 import unibook.model.person.Person;
 
 /**
@@ -20,15 +21,18 @@ import unibook.model.person.Person;
 class JsonSerializableUniBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
-
+    public static final String MESSAGE_DUPLICATE_MODULE = "Module list contains duplicate module(s).";
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedModule> modules = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableUniBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableUniBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableUniBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                   @JsonProperty("modules") List<JsonAdaptedModule> modules) {
         this.persons.addAll(persons);
+        this.modules.addAll(modules);
     }
 
     /**
@@ -38,6 +42,7 @@ class JsonSerializableUniBook {
      */
     public JsonSerializableUniBook(ReadOnlyUniBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        modules.addAll(source.getModuleList().stream().map(JsonAdaptedModule::new).collect(Collectors.toList()));
     }
 
     /**
@@ -53,6 +58,14 @@ class JsonSerializableUniBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             uniBook.addPerson(person);
+        }
+
+        for (JsonAdaptedModule jsonAdaptedModule : modules) {
+            Module module = jsonAdaptedModule.toModelType();
+            if (uniBook.hasModule(module)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_MODULE);
+            }
+            uniBook.addModule(module);
         }
         return uniBook;
     }

--- a/src/test/data/JsonSerializableUniBookTest/duplicatePersonUniBook.json
+++ b/src/test/data/JsonSerializableUniBookTest/duplicatePersonUniBook.json
@@ -13,5 +13,6 @@
       "phone": "94351253",
       "email": "pauline@example.com"
     }
-  ]
+  ],
+  "modules" : [ ]
 }

--- a/src/test/data/JsonSerializableUniBookTest/invalidPersonUniBook.json
+++ b/src/test/data/JsonSerializableUniBookTest/invalidPersonUniBook.json
@@ -5,5 +5,6 @@
       "phone": "9482424",
       "email": "invalid@email!3e"
     }
-  ]
+  ],
+  "modules" : [ ]
 }

--- a/src/test/data/JsonSerializableUniBookTest/typicalPersonsUniBook.json
+++ b/src/test/data/JsonSerializableUniBookTest/typicalPersonsUniBook.json
@@ -50,5 +50,6 @@
       "email": "anna@example.com",
       "tagged": []
     }
-  ]
+  ],
+  "modules" : [ ]
 }


### PR DESCRIPTION
- Add `JSONAdaptedModule.java` class (TODO: add support for list of students and professors, currently always defaults to empty list when deserialising from json and does not account for the list when serialising to json)
- Using `SampleDataUtil`, defaults to a list with 3 people (Alice Yeoh, Bernice Yu, Charlotte Oliviero) and 2 modules (CS2103 Software Engineering, CS2106 Introduction to Operating Systems)
- If `data/unibook.json` is not present, running the program will automatically load the above info into `unibook.json`. 
- If `data/unibook.json` is present it will read `unibook.json` and display the appropriate persons, while adding the modules to the underlying `ModuleList` (Note that 
GUI implementation for Module display is still incomplete so you won't see a difference)
- Updated some of the test files so it would pass `gradlew check coverage`.
- TODO: Add Jackson functionality/compatability for `ObservableList` of students and professors within `Module`. I was not able to figure that one out (therefore in `Module.java` you can see that I have added `@JsonIgnoreProperties` so Jackson will temporarily ignore these fields. Need some help here to figure it out. Thanks!