### PR TITLE
Fix HashCode in Module and Person

### DIFF
--- a/src/main/java/unibook/model/module/Module.java
+++ b/src/main/java/unibook/model/module/Module.java
@@ -178,7 +178,7 @@ public class Module {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(moduleName, moduleCode, professors, students);
+        return Objects.hash(moduleName, moduleCode);
     }
 
     @Override

--- a/src/main/java/unibook/model/person/Person.java
+++ b/src/main/java/unibook/model/person/Person.java
@@ -106,7 +106,7 @@ public class Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, tags, modules);
+        return Objects.hash(name, phone, email, tags);
     }
 
     @Override

--- a/src/main/java/unibook/model/person/Student.java
+++ b/src/main/java/unibook/model/person/Student.java
@@ -51,7 +51,7 @@ public class Student extends Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(getName(), getPhone(), getEmail(), getTags(), getModules());
+        return Objects.hash(getName(), getPhone(), getEmail(), getTags());
     }
 
     @Override


### PR DESCRIPTION
Previously the hashCode() in Module is calling the hashCode() of Person, which will call the hashCode() of Module and result in an endless recursion.

Fixed by removing the hashing of person in Module, and hashing of module in Person.