### PR TITLE
Enhance current Add Command to take in options

### DIFF
--- a/src/main/java/unibook/logic/commands/AddCommand.java
+++ b/src/main/java/unibook/logic/commands/AddCommand.java
@@ -84,12 +84,13 @@ public class AddCommand extends Command {
             } else if (!model.isModuleExist(personToAdd)) {
                 throw new CommandException(MESSAGE_MODULE_DOES_NOT_EXIST);
             }
-            Set<ModuleCode> moduleCodes = personToAdd.getModuleCodes();
-            Set<Module> modules = personToAdd.getModulesModifiable();
-            for (ModuleCode moduleCode : moduleCodes) {
-                modules.add(model.getModule(moduleCode));
+            Set<ModuleCode> personModuleCodes = personToAdd.getModuleCodes();
+            Set<Module> personModules = personToAdd.getModulesModifiable();
+            for (ModuleCode moduleCode : personModuleCodes) {
+                Module toAdd = model.getModuleByCode(moduleCode);
+                personModules.add(toAdd);
             }
-
+            model.addPersonToTheirModules(personToAdd);
             model.addPerson(personToAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS_PERSON, personToAdd));
         }

--- a/src/main/java/unibook/logic/commands/AddCommand.java
+++ b/src/main/java/unibook/logic/commands/AddCommand.java
@@ -2,60 +2,103 @@ package unibook.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Set;
+
 import unibook.logic.commands.exceptions.CommandException;
 import unibook.logic.parser.CliSyntax;
 import unibook.model.Model;
+import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
+import unibook.model.module.ModuleName;
 import unibook.model.person.Person;
 
 /**
- * Adds a person to the UniBook.
+ * Adds a person or module to the UniBook.
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the UniBook. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a student/professor/module to the UniBook. "
         + "Parameters: "
+        + CliSyntax.PREFIX_OPTION + "OPTION "
         + CliSyntax.PREFIX_NAME + "NAME "
-        + CliSyntax.PREFIX_PHONE + "PHONE "
-        + CliSyntax.PREFIX_EMAIL + "EMAIL "
-        + "[" + CliSyntax.PREFIX_TAG + "TAG]...\n"
+        + "[" + CliSyntax.PREFIX_PHONE + "PHONE] "
+        + "[" + CliSyntax.PREFIX_EMAIL + "EMAIL] "
+        + "[" + CliSyntax.PREFIX_TAG + "TAG]... "
+        + "[" + CliSyntax.PREFIX_MODULE + "MODULE]...\n"
         + "Example: " + COMMAND_WORD + " "
+        + CliSyntax.PREFIX_OPTION + "student "
         + CliSyntax.PREFIX_NAME + "John Doe "
         + CliSyntax.PREFIX_PHONE + "98765432 "
         + CliSyntax.PREFIX_EMAIL + "johnd@example.com "
         + CliSyntax.PREFIX_TAG + "friends "
-        + CliSyntax.PREFIX_TAG + "owesMoney";
+        + CliSyntax.PREFIX_TAG + "owesMoney "
+        + CliSyntax.PREFIX_MODULE + "CS2103 "
+        + CliSyntax.PREFIX_MODULE + "CS2105";
 
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
+    public static final String MESSAGE_SUCCESS_PERSON = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the UniBook";
 
-    private final Person toAdd;
+    public static final String MESSAGE_SUCCESS_MODULE = "New module added: %1$s";
+    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the UniBook";
+
+    public static final String MESSAGE_MODULE_DOES_NOT_EXIST = "One or more of the modules entered"
+            + " does not exist in the UniBook";
+
+    private Person personToAdd = new Person();
+    private Module moduleToAdd = new Module();
 
     /**
      * Creates an AddCommand to add the specified {@code Person}
      */
     public AddCommand(Person person) {
         requireNonNull(person);
-        toAdd = person;
+        personToAdd = person;
+    }
+
+    /**
+     * Creates an AddCommand to add the specified {@code Module}
+     */
+    public AddCommand(ModuleName moduleName, ModuleCode moduleCode) {
+        requireNonNull(moduleName);
+        requireNonNull(moduleCode);
+        Module module = new Module(moduleName, moduleCode);
+        moduleToAdd = module;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
-        }
+        if (personToAdd.getName() == null) {
+            if (model.hasModule(moduleToAdd)) {
+                throw new CommandException(MESSAGE_DUPLICATE_MODULE);
+            }
 
-        model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+            model.addModule(moduleToAdd);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_MODULE, moduleToAdd));
+        } else {
+            if (model.hasPerson(personToAdd)) {
+                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            } else if (!model.isModuleExist(personToAdd)) {
+                throw new CommandException(MESSAGE_MODULE_DOES_NOT_EXIST);
+            }
+            Set<ModuleCode> moduleCodes = personToAdd.getModuleCodes();
+            Set<Module> modules = personToAdd.getModulesModifiable();
+            for (ModuleCode moduleCode : moduleCodes) {
+                modules.add(model.getModule(moduleCode));
+            }
+
+            model.addPerson(personToAdd);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_PERSON, personToAdd));
+        }
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof AddCommand // instanceof handles nulls
-            && toAdd.equals(((AddCommand) other).toAdd));
+            && personToAdd.equals(((AddCommand) other).personToAdd));
     }
 }

--- a/src/main/java/unibook/logic/parser/CliSyntax.java
+++ b/src/main/java/unibook/logic/parser/CliSyntax.java
@@ -13,4 +13,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_MODULE = new Prefix("m/");
     public static final Prefix PREFIX_NEWMOD = new Prefix("nm/");
+    public static final Prefix PREFIX_OFFICE = new Prefix("a/");
 }

--- a/src/main/java/unibook/logic/parser/ParserUtil.java
+++ b/src/main/java/unibook/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import unibook.commons.core.index.Index;
@@ -14,6 +15,7 @@ import unibook.model.module.ModuleCode;
 import unibook.model.module.ModuleName;
 import unibook.model.person.Email;
 import unibook.model.person.Name;
+import unibook.model.person.Office;
 import unibook.model.person.Phone;
 import unibook.model.tag.Tag;
 
@@ -108,7 +110,7 @@ public class ParserUtil {
      */
     public static ModuleCode parseModuleCode(String moduleCode) throws ParseException {
         requireNonNull(moduleCode);
-        String trimmedCode = moduleCode.trim();
+        String trimmedCode = moduleCode.trim().toUpperCase(Locale.ROOT);
         if (!ModuleCode.isValidModuleCode(trimmedCode)) {
             throw new ParseException(ModuleCode.MESSAGE_CONSTRAINTS);
         }
@@ -144,7 +146,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code Collection<String> modules} into a {@code Set<Module>}.
+     * Parses {@code Collection<String> modules} into a single {@code Set<Module>}.
      */
     public static Set<Module> parseModules(Collection<String> modules) throws ParseException {
         requireNonNull(modules);
@@ -159,5 +161,33 @@ public class ParserUtil {
         Module newmod = new Module(modName, modCode);
         moduleSet.add(newmod);
         return moduleSet;
+    }
+
+    /**
+     * Parses {@code Collection<String> modules} into a {@code Set<ModuleCode>}.
+     */
+    public static Set<ModuleCode> parseMultipleModules(Collection<String> moduleCodes) throws ParseException {
+        requireNonNull(moduleCodes);
+        final Set<ModuleCode> moduleSet = new HashSet<>();
+        if (moduleCodes.toArray().length == 0) {
+            return moduleSet;
+        }
+        for (String moduleCode : moduleCodes) {
+            ModuleCode mc = new ModuleCode(moduleCode.toUpperCase());
+            moduleSet.add(mc);
+        }
+        return moduleSet;
+    }
+
+    /**
+     * Parses {@code String office} into an {@code Office}.
+     */
+    public static Office parseOffice(String office) throws ParseException {
+        requireNonNull(office);
+        String trimmedOffice = office.trim();
+        if (!Office.isValidOffice(trimmedOffice)) {
+            throw new ParseException(Office.MESSAGE_CONSTRAINTS);
+        }
+        return new Office(trimmedOffice);
     }
 }

--- a/src/main/java/unibook/model/Model.java
+++ b/src/main/java/unibook/model/Model.java
@@ -78,6 +78,12 @@ public interface Model {
     void addPerson(Person person);
 
     /**
+     * Adds the given person to all of its modules.
+     * {@code person} must exist in the UniBook.
+     */
+    void addPersonToTheirModules(Person person);
+
+    /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the UniBook.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the UniBook.
@@ -114,7 +120,7 @@ public interface Model {
      * Finds the corresponding module to the module code.
      * @return Module belonging to the ModuleCode
      */
-    Module getModule(ModuleCode moduleCode);
+    Module getModuleByCode(ModuleCode moduleCode);
 
     ObservableList<Module> getFilteredModuleList();
 

--- a/src/main/java/unibook/model/Model.java
+++ b/src/main/java/unibook/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import unibook.commons.core.GuiSettings;
 import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
 
 
@@ -99,10 +100,21 @@ public interface Model {
 
     void deleteModule(Module target);
 
-
+    /**
+     * Adds the given module.
+     * {@code module} must not already exist in the UniBook.
+     */
     void addModule(Module module);
 
     void setModule(Module target, Module editedModule);
+
+    boolean isModuleExist(Person person);
+
+    /**
+     * Finds the corresponding module to the module code.
+     * @return Module belonging to the ModuleCode
+     */
+    Module getModule(ModuleCode moduleCode);
 
     ObservableList<Module> getFilteredModuleList();
 

--- a/src/main/java/unibook/model/ModelManager.java
+++ b/src/main/java/unibook/model/ModelManager.java
@@ -3,6 +3,7 @@ package unibook.model;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -12,6 +13,7 @@ import unibook.commons.core.GuiSettings;
 import unibook.commons.core.LogsCenter;
 import unibook.commons.util.CollectionUtil;
 import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
 
 
@@ -138,6 +140,22 @@ public class ModelManager implements Model {
         CollectionUtil.requireAllNonNull(target, editedModule);
 
         uniBook.setModule(target, editedModule);
+    }
+
+    @Override
+    public boolean isModuleExist(Person person) {
+        Set<ModuleCode> moduleCodes = person.getModuleCodes();
+        for (ModuleCode moduleCode : moduleCodes) {
+            if (!uniBook.hasModule(moduleCode)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public Module getModule(ModuleCode moduleCode) {
+        return uniBook.getModuleByCode(moduleCode);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/unibook/model/ModelManager.java
+++ b/src/main/java/unibook/model/ModelManager.java
@@ -15,6 +15,7 @@ import unibook.commons.util.CollectionUtil;
 import unibook.model.module.Module;
 import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
+import unibook.model.person.exceptions.PersonNoSubtypeException;
 
 
 /**
@@ -111,6 +112,15 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addPersonToTheirModules(Person person) {
+        try {
+            uniBook.addPersonToAllTheirModuleCodes(person);
+        } catch (PersonNoSubtypeException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
     public void setPerson(Person target, Person editedPerson) {
         CollectionUtil.requireAllNonNull(target, editedPerson);
 
@@ -154,7 +164,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Module getModule(ModuleCode moduleCode) {
+    public Module getModuleByCode(ModuleCode moduleCode) {
         return uniBook.getModuleByCode(moduleCode);
     }
 

--- a/src/main/java/unibook/model/UniBook.java
+++ b/src/main/java/unibook/model/UniBook.java
@@ -115,6 +115,26 @@ public class UniBook implements ReadOnlyUniBook {
     }
 
     /**
+     * Adds this person to all the module codes that they are associated with, into the
+     * correct personnel list (professor/student) in module depending on the runtime type
+     * of this person.
+     *
+     * @param p person whos modules to add them to
+     */
+    public void addPersonToAllTheirModuleCodes(Person p) throws PersonNoSubtypeException {
+        for (ModuleCode personsModuleCodes : p.getModuleCodes()) {
+            Module module = modules.getModuleByCode(personsModuleCodes);
+            if (p instanceof Student) {
+                module.addStudent((Student) p);
+            } else if (p instanceof Professor) {
+                module.addProfessor((Professor) p);
+            } else {
+                throw new PersonNoSubtypeException();
+            }
+        }
+    }
+
+    /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the UniBook.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the UniBook.

--- a/src/main/java/unibook/model/module/Module.java
+++ b/src/main/java/unibook/model/module/Module.java
@@ -74,6 +74,16 @@ public class Module {
     }
 
     /**
+     * Empty constructor for a null module.
+     */
+    public Module() {
+        this.moduleName = null;
+        this.moduleCode = null;
+        this.professors = null;
+        this.students = null;
+    }
+
+    /**
      * Returns the module name.
      *
      * @return the name of the module.

--- a/src/main/java/unibook/model/module/Module.java
+++ b/src/main/java/unibook/model/module/Module.java
@@ -188,7 +188,7 @@ public class Module {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(moduleName, moduleCode, professors, students);
+        return Objects.hash(moduleName, moduleCode);
     }
 
     @Override

--- a/src/main/java/unibook/model/module/ModuleCode.java
+++ b/src/main/java/unibook/model/module/ModuleCode.java
@@ -31,7 +31,7 @@ public class ModuleCode {
     }
 
     /**
-     * Returns true if a given string is a valid module name.
+     * Returns true if a given string is a valid module code.
      */
     public static boolean isValidModuleCode(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/unibook/model/module/ModuleList.java
+++ b/src/main/java/unibook/model/module/ModuleList.java
@@ -44,6 +44,7 @@ public class ModuleList implements Iterable<Module> {
      */
     public void add(Module toAdd) {
         requireNonNull(toAdd);
+
         if (contains(toAdd)) {
             throw new DuplicateModuleException();
         }

--- a/src/main/java/unibook/model/module/ModuleList.java
+++ b/src/main/java/unibook/model/module/ModuleList.java
@@ -20,7 +20,7 @@ public class ModuleList implements Iterable<Module> {
         FXCollections.unmodifiableObservableList(internalList);
 
     /**
-     * Returns true if the list contains an equivalent person as the given argument.
+     * Returns true if the list contains an equivalent module as the given argument.
      */
     public boolean contains(Module toCheck) {
         requireNonNull(toCheck);

--- a/src/main/java/unibook/model/person/Office.java
+++ b/src/main/java/unibook/model/person/Office.java
@@ -31,7 +31,7 @@ public class Office {
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Returns true if a given string is a valid office.
      */
     public static boolean isValidOffice(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/unibook/model/person/Person.java
+++ b/src/main/java/unibook/model/person/Person.java
@@ -111,6 +111,13 @@ public class Person {
     }
 
     /**
+     * Adds a module to the module set
+     */
+    public void addModule(Module module) {
+        modules.add(module);
+    }
+
+    /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
      */
@@ -148,7 +155,7 @@ public class Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, tags, modules);
+        return Objects.hash(name, phone, email, tags);
     }
 
     @Override

--- a/src/main/java/unibook/model/person/Person.java
+++ b/src/main/java/unibook/model/person/Person.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import unibook.commons.util.CollectionUtil;
 import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
 import unibook.model.tag.Tag;
 
 /**
@@ -26,6 +27,9 @@ public class Person {
     // Data fields
     private final Set<Tag> tags = new HashSet<>();
 
+    // Temporary field to store module codes that a person is associated with.
+    private final Set<ModuleCode> moduleCodes = new HashSet<>();
+
     /**
      * Every field must be present and not null.
      */
@@ -36,6 +40,29 @@ public class Person {
         this.phone = phone;
         this.tags.addAll(tags);
         this.modules.addAll(modules);
+    }
+
+    /**
+     * Constructor of Person with extra ModuleCode parameter.
+     */
+    public Person(Name name, Phone phone, Email email, Set<Tag> tags,
+                  Set<Module> modules, Set<ModuleCode> moduleCodes) {
+        CollectionUtil.requireAllNonNull(name, phone, email, tags);
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.tags.addAll(tags);
+        this.modules.addAll(modules);
+        this.moduleCodes.addAll(moduleCodes);
+    }
+
+    /**
+     * Empty constructor of a null person.
+     */
+    public Person() {
+        this.name = null;
+        this.phone = null;
+        this.email = null;
     }
 
     public Name getName() {
@@ -49,7 +76,6 @@ public class Person {
     public Email getEmail() {
         return email;
     }
-
 
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
@@ -66,6 +92,22 @@ public class Person {
      */
     public Set<Module> getModules() {
         return Collections.unmodifiableSet(modules);
+    }
+
+    /**
+     * Returns a mutable module set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Module> getModulesModifiable() {
+        return modules;
+    }
+
+    /**
+     * Returns an immutable modulecode set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<ModuleCode> getModuleCodes() {
+        return Collections.unmodifiableSet(moduleCodes);
     }
 
     /**

--- a/src/main/java/unibook/model/person/Professor.java
+++ b/src/main/java/unibook/model/person/Professor.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
 import unibook.model.tag.Tag;
 
 /**
@@ -19,6 +20,15 @@ public class Professor extends Person {
      */
     public Professor(Name name, Phone phone, Email email, Set<Tag> tags, Office office, Set<Module> modules) {
         super(name, phone, email, tags, modules);
+        this.office = office;
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Professor(Name name, Phone phone, Email email, Set<Tag> tags, Office office,
+                     Set<Module> modules, Set<ModuleCode> moduleCodes) {
+        super(name, phone, email, tags, modules, moduleCodes);
         this.office = office;
     }
 

--- a/src/main/java/unibook/model/person/Student.java
+++ b/src/main/java/unibook/model/person/Student.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
 import unibook.model.tag.Tag;
 
 /**
@@ -17,6 +18,14 @@ public class Student extends Person {
      */
     public Student(Name name, Phone phone, Email email, Set<Tag> tags, Set<Module> modules) {
         super(name, phone, email, tags, modules);
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Student(Name name, Phone phone, Email email, Set<Tag> tags,
+                   Set<Module> modules, Set<ModuleCode> moduleCodes) {
+        super(name, phone, email, tags, modules, moduleCodes);
     }
 
     /**

--- a/src/main/java/unibook/model/person/Student.java
+++ b/src/main/java/unibook/model/person/Student.java
@@ -60,7 +60,7 @@ public class Student extends Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(getName(), getPhone(), getEmail(), getTags(), getModules());
+        return Objects.hash(getName(), getPhone(), getEmail(), getTags());
     }
 
     @Override

--- a/src/main/java/unibook/ui/MainWindow.java
+++ b/src/main/java/unibook/ui/MainWindow.java
@@ -126,6 +126,7 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+        setModuleListPanel();
     }
 
     /**

--- a/src/test/java/unibook/logic/LogicManagerTest.java
+++ b/src/test/java/unibook/logic/LogicManagerTest.java
@@ -76,8 +76,8 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Execute add command
-        String addCommand = AddCommand.COMMAND_WORD + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
-            + CommandTestUtil.EMAIL_DESC_AMY;
+        String addCommand = AddCommand.COMMAND_WORD + CommandTestUtil.OPTION_DESC_STUDENT
+                + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.EMAIL_DESC_AMY;
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);

--- a/src/test/java/unibook/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/unibook/logic/commands/AddCommandIntegrationTest.java
@@ -32,7 +32,7 @@ public class AddCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new AddCommand(validPerson), model,
-            String.format(AddCommand.MESSAGE_SUCCESS, validPerson), expectedModel);
+            String.format(AddCommand.MESSAGE_SUCCESS_PERSON, validPerson), expectedModel);
     }
 
     @Test

--- a/src/test/java/unibook/logic/commands/AddCommandTest.java
+++ b/src/test/java/unibook/logic/commands/AddCommandTest.java
@@ -117,6 +117,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addPersonToTheirModules(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ReadOnlyUniBook getUniBook() {
             throw new AssertionError("This method should not be called.");
         }
@@ -177,7 +182,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public Module getModule(ModuleCode moduleCode) {
+        public Module getModuleByCode(ModuleCode moduleCode) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -237,6 +242,10 @@ public class AddCommandTest {
         public boolean isModuleExist(Person person) {
             requireNonNull(person);
             return true;
+        }
+
+        @Override
+        public void addPersonToTheirModules(Person person) {
         }
     }
 

--- a/src/test/java/unibook/logic/commands/AddCommandTest.java
+++ b/src/test/java/unibook/logic/commands/AddCommandTest.java
@@ -20,6 +20,7 @@ import unibook.model.ReadOnlyUniBook;
 import unibook.model.ReadOnlyUserPrefs;
 import unibook.model.UniBook;
 import unibook.model.module.Module;
+import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
 import unibook.testutil.Assert;
 import unibook.testutil.PersonBuilder;
@@ -38,7 +39,7 @@ public class AddCommandTest {
 
         CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validPerson), commandResult.getFeedbackToUser());
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS_PERSON, validPerson), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }
 
@@ -171,6 +172,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean isModuleExist(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Module getModule(ModuleCode moduleCode) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Module> getFilteredModuleList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -220,6 +231,12 @@ public class AddCommandTest {
         @Override
         public ReadOnlyUniBook getUniBook() {
             return new UniBook();
+        }
+
+        @Override
+        public boolean isModuleExist(Person person) {
+            requireNonNull(person);
+            return true;
         }
     }
 

--- a/src/test/java/unibook/logic/commands/CommandTestUtil.java
+++ b/src/test/java/unibook/logic/commands/CommandTestUtil.java
@@ -22,6 +22,13 @@ import unibook.testutil.EditPersonDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    public static final String VALID_OPTION_MODULE = "module";
+    public static final String VALID_OPTION_STUDENT = "student";
+    public static final String VALID_OPTION_PROFESSOR = "professor";
+    public static final String VALID_MODULE_COMPORG = "Computer Organisation";
+    public static final String VALID_MODULE_DISMATH = "Discrete Mathematics";
+    public static final String VALID_MODULECODE_COMPORG = "CS2100";
+    public static final String VALID_MODULECODE_DISMATH = "CS1231S";
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
@@ -30,22 +37,36 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+    public static final String VALID_ADDRESS_PROFESSOR = "Block 312, Amy Street 1";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String OPTION_DESC_MODULE = " " + CliSyntax.PREFIX_OPTION + VALID_OPTION_MODULE;
+    public static final String OPTION_DESC_STUDENT = " " + CliSyntax.PREFIX_OPTION + VALID_OPTION_STUDENT;
+    public static final String OPTION_DESC_PROFESSOR = " " + CliSyntax.PREFIX_OPTION + VALID_OPTION_PROFESSOR;
     public static final String NAME_DESC_AMY = " " + CliSyntax.PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + CliSyntax.PREFIX_NAME + VALID_NAME_BOB;
+    public static final String NAME_DESC_COMPORG = " " + CliSyntax.PREFIX_NAME + VALID_MODULE_COMPORG;
+    public static final String NAME_DESC_DISMATH = " " + CliSyntax.PREFIX_NAME + VALID_MODULE_DISMATH;
     public static final String PHONE_DESC_AMY = " " + CliSyntax.PREFIX_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + CliSyntax.PREFIX_PHONE + VALID_PHONE_BOB;
     public static final String EMAIL_DESC_AMY = " " + CliSyntax.PREFIX_EMAIL + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + CliSyntax.PREFIX_EMAIL + VALID_EMAIL_BOB;
+    public static final String ADDRESS_DESC_AMY = " " + CliSyntax.PREFIX_OFFICE + VALID_ADDRESS_AMY;
+    public static final String ADDRESS_DESC_BOB = " " + CliSyntax.PREFIX_OFFICE + VALID_ADDRESS_BOB;
+    public static final String ADDRESS_DESC_PROFESSOR = " " + CliSyntax.PREFIX_OFFICE + VALID_ADDRESS_PROFESSOR;
     public static final String TAG_DESC_FRIEND = " " + CliSyntax.PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + CliSyntax.PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String MODULE_DESC_COMPORG = " " + CliSyntax.PREFIX_MODULE + VALID_MODULECODE_COMPORG;
+    public static final String MODULE_DESC_DISMATH = " " + CliSyntax.PREFIX_MODULE + VALID_MODULECODE_DISMATH;
 
+    public static final String INVALID_OPTION_DESC = " "
+            + CliSyntax.PREFIX_OPTION + "STUDENT"; // only 'student'/'module'/'professor' allowed in option
     public static final String INVALID_NAME_DESC = " " + CliSyntax.PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + CliSyntax.PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + CliSyntax.PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
-    // empty string not allowed for addresses
+    public static final String INVALID_ADDRESS_DESC = " "
+            + CliSyntax.PREFIX_OFFICE + " "; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + CliSyntax.PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/unibook/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/unibook/logic/parser/AddCommandParserTest.java
@@ -26,108 +26,120 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser,
-            CommandTestUtil.PREAMBLE_WHITESPACE + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
-                + CommandTestUtil.EMAIL_DESC_BOB
-                + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+            CommandTestUtil.PREAMBLE_WHITESPACE + CommandTestUtil.OPTION_DESC_STUDENT
+                    + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
+                    + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple names - last name accepted
-        assertParseSuccess(parser,
-            CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
-                + CommandTestUtil.EMAIL_DESC_BOB
-                + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+        assertParseSuccess(parser, CommandTestUtil.OPTION_DESC_STUDENT + CommandTestUtil.NAME_DESC_AMY
+                + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
+                + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple phones - last phone accepted
-        assertParseSuccess(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.PHONE_DESC_BOB
-                + CommandTestUtil.EMAIL_DESC_BOB
-                + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+        assertParseSuccess(parser, CommandTestUtil.OPTION_DESC_STUDENT + CommandTestUtil.NAME_DESC_BOB
+                + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.PHONE_DESC_BOB
+                + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple emails - last email accepted
-        assertParseSuccess(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_AMY
+        assertParseSuccess(parser, CommandTestUtil.OPTION_DESC_STUDENT + CommandTestUtil.NAME_DESC_BOB
+                + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_AMY
                 + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
-                + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                CommandTestUtil.OPTION_DESC_STUDENT + CommandTestUtil.NAME_DESC_BOB
+                        + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
+                        + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags =
-            new PersonBuilder(TypicalPersons.BOB).withTags(CommandTestUtil.VALID_TAG_FRIEND,
-                    CommandTestUtil.VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
-                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND,
-            new AddCommand(expectedPersonMultipleTags));
+                new PersonBuilder(TypicalPersons.BOB).withTags(CommandTestUtil.VALID_TAG_FRIEND,
+                    CommandTestUtil.VALID_TAG_HUSBAND).build();
+        assertParseSuccess(parser, CommandTestUtil.OPTION_DESC_STUDENT + CommandTestUtil.NAME_DESC_BOB
+                        + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
+                        + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND,
+                new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withTags().build();
-        assertParseSuccess(parser,
-            CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.EMAIL_DESC_AMY,
-            new AddCommand(expectedPerson));
+        assertParseSuccess(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                        + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
+                        + CommandTestUtil.EMAIL_DESC_AMY, new AddCommand(expectedPerson));
     }
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
+        // missing option prefix
+        assertParseFailure(parser, CommandTestUtil.VALID_OPTION_STUDENT
+                        + CommandTestUtil.NAME_DESC_BOB
+                        + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB,
+                expectedMessage);
+
         // missing name prefix
-        assertParseFailure(parser,
-            CommandTestUtil.VALID_NAME_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB,
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                        + CommandTestUtil.VALID_NAME_BOB
+                        + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB,
             expectedMessage);
 
         // missing phone prefix
-        assertParseFailure(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.VALID_PHONE_BOB + CommandTestUtil.EMAIL_DESC_BOB,
-            expectedMessage);
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                        + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.VALID_PHONE_BOB
+                        + CommandTestUtil.EMAIL_DESC_BOB, expectedMessage);
 
         // missing email prefix
-        assertParseFailure(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.VALID_EMAIL_BOB,
-            expectedMessage);
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                        + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
+                        + CommandTestUtil.VALID_EMAIL_BOB, expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser,
-            CommandTestUtil.VALID_NAME_BOB + CommandTestUtil.VALID_PHONE_BOB + CommandTestUtil.VALID_EMAIL_BOB,
+        assertParseFailure(parser, CommandTestUtil.VALID_OPTION_STUDENT
+                + CommandTestUtil.VALID_NAME_BOB + CommandTestUtil.VALID_PHONE_BOB + CommandTestUtil.VALID_EMAIL_BOB,
             expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
+        // invalid option
+        assertParseFailure(parser, CommandTestUtil.INVALID_OPTION_DESC
+                + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
+                + CommandTestUtil.TAG_DESC_HUSBAND
+                + CommandTestUtil.TAG_DESC_FRIEND, AddCommandParser.MESSAGE_CONSTRAINTS_OPTION);
+
         // invalid name
-        assertParseFailure(parser,
-            CommandTestUtil.INVALID_NAME_DESC + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                + CommandTestUtil.INVALID_NAME_DESC + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
-        assertParseFailure(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.INVALID_PHONE_DESC + CommandTestUtil.EMAIL_DESC_BOB
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.INVALID_PHONE_DESC + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
-        assertParseFailure(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.INVALID_EMAIL_DESC
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.INVALID_EMAIL_DESC
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
         // invalid tag
-        assertParseFailure(parser,
-            CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.INVALID_TAG_DESC + CommandTestUtil.VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser,
-            CommandTestUtil.INVALID_NAME_DESC + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB,
+        assertParseFailure(parser, CommandTestUtil.OPTION_DESC_STUDENT
+                + CommandTestUtil.INVALID_NAME_DESC + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB,
             Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser,
-            CommandTestUtil.PREAMBLE_NON_EMPTY + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
+            CommandTestUtil.PREAMBLE_NON_EMPTY + CommandTestUtil.OPTION_DESC_STUDENT
+                    + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
                 + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND,
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));

--- a/src/test/java/unibook/testutil/PersonBuilder.java
+++ b/src/test/java/unibook/testutil/PersonBuilder.java
@@ -20,6 +20,7 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
 
+    private String option;
     private Name name;
     private Phone phone;
     private Email email;

--- a/src/test/java/unibook/testutil/PersonUtil.java
+++ b/src/test/java/unibook/testutil/PersonUtil.java
@@ -18,7 +18,7 @@ public class PersonUtil {
      * Returns an add command string for adding the {@code person}.
      */
     public static String getAddCommand(Person person) {
-        return AddCommand.COMMAND_WORD + " " + getPersonDetails(person);
+        return AddCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_OPTION + "student " + getPersonDetails(person);
     }
 
     /**


### PR DESCRIPTION
Enhanced Add Command can now do the following

1. Add a Module
E.g., `add o/module n/Discrete Mathematics m/CS1231S`
This adds a Module with name: Discrete Mathematics and code: CS1231S to the UniBook.

2. Add a Student
E.g., `add o/student n/Johnston p/98765432 e/johnston@gmail.com t/friend m/CS1231S m/CS2103`
This adds a Student to the UniBook, it also adds the student into the student list of the corresponding Module objects (CS1231S and CS2103).

3. Add a Professor
E.g., `add o/professor n/Aaron Tan p/98723432 e/aarontan@gmail.com a/COM2 01-15 t/smart m/CS1231S m/CS2100`
This adds a Professor to the UniBook, it also adds the professor into the professor list of the corresponding Module objects (CS1231S and CS2100).

Error cases:
- If user tries to add a Student/Professor with a module that does not exist in the UniBook, an error message will be displayed to notify the user that one or more modules entered do not currently exist. 
- If module/person already exists in UniBook, an error message will be displayed to notify user about the duplicate module/person. 
- If the add command fields are incorrect, an error message will be displayed to notify user on how to use the add command properly/how to populate each field properly.

To do for future enhancements:
1. Add more unit tests for whether the personlist in module is being updated.
2. Add more unit tests to check if module is being added to the UniBook.