### PR TITLE
Update list command to accept user specified criteria

### DIFF
--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -1,0 +1,2 @@
+package unibook.logic.parser;public class ListCommandParser {
+}


### PR DESCRIPTION
- Added functionality to display specified criteria when `Persons` are being shown. 
- The functionality to display specified `Module` is currently not done as it is still not totally clear how we want that to work, but adding it should be trivial later on.
- Please follow the following format for the commands instead of the User Guide (as user guide includes those for groups)

- `list o/module m/<MODULECODE>`
Lists all people associated with a specified module.
Example: `list o/module m/CS2103` will list all people associated with the module `CS2103`.

- `list o/type ty/<TYPE>`
Lists all people with a specified type.
Example: `list o/type ty/professors` will list all professors. `list o/type ty/students` will list all students.

- `list o/module m/<MODULECODE> ty/<TYPE>`
Lists all people with a specified type, in a specified module.
Example: `list o/module m/CS2103 ty/students` will list all students in module `CS2103`.

Do let me know if you encounter any problems. Thank you!