### PR TITLE
Update list command to accept user specified criteria

### DIFF
--- a/src/main/java/unibook/MainApp.java
+++ b/src/main/java/unibook/MainApp.java
@@ -66,6 +66,9 @@ public class MainApp extends Application {
         logic = new LogicManager(model, storage);
 
         ui = new UiManager(logic);
+
+        ModelManager modelManager = (ModelManager) model;
+        modelManager.setUi(ui);
     }
 
     /**

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -2,23 +2,119 @@ package unibook.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import unibook.model.Model;
+import java.util.function.Predicate;
 
+import unibook.model.Model;
+import unibook.model.module.ModuleCode;
+import unibook.model.person.Person;
+import unibook.model.person.Professor;
+import unibook.model.person.Student;
 /**
- * Lists all persons in the unibook to the user.
+ * Lists all persons in the UniBook according to the user specified criteria.
  */
 public class ListCommand extends Command {
 
+
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed everything.";
+    public static final String MESSAGE_SUCCESS_MODULE = "Listed all persons with specified module.";
+    public static final String MESSAGE_SUCCESS_TYPE = "Listed all persons with specified type.";
+    public static final String MESSAGE_SUCCESS_MODULEANDTYPE = "Listed all persons with specified type "
+            + "in specified module.";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists according to the given criteria\n "
+            + "Parameters: option (either module or type) \n"
+            + "Example: list o/module m/cs2103\n";
+
+    private enum ListCommandType {
+        ALL, MODULE, TYPE, MODULEANDTYPE
+    };
+
+    private ModuleCode moduleCode;
+    private String type;
+    private ListCommandType commandType;
+
+    /**
+     * Constructor for a ListCommand to list everything.
+     */
+    public ListCommand() {
+        this.commandType = ListCommandType.ALL;
+    }
+
+    /**
+     * Constructor for a ListCommand to list people with specific module.
+     * @param moduleCode
+     */
+    public ListCommand(ModuleCode moduleCode) {
+        this.commandType = ListCommandType.MODULE;
+        this.moduleCode = moduleCode;
+    }
+
+    /**
+     * Constructor for a ListCommand to list people with specific type.
+     * @param type
+     */
+    public ListCommand(String type) {
+        this.commandType = ListCommandType.TYPE;
+        this.type = type;
+    }
+
+    /**
+     * Constructor for a ListCommand to list people with specific type in a
+     * specific module.
+     * @param moduleCode
+     * @param type
+     */
+    public ListCommand(ModuleCode moduleCode, String type) {
+        this.commandType = ListCommandType.MODULEANDTYPE;
+        this.moduleCode = moduleCode;
+        this.type = type;
+    }
+
+    /**
+     * Utility method to quickly show everything. Used to reset before narrowing
+     * to specific criteria.
+     * @param model
+     */
+    private void showAll(Model model) {
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
+    }
 
     @Override
     public CommandResult execute(Model model, Boolean isPersonListShowing,
                                  Boolean isModuleListShowing) {
         requireNonNull(model);
-        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        showAll(model);
+        switch (commandType) {
+        case ALL:
+            return new CommandResult(MESSAGE_SUCCESS);
+        case MODULE:
+            Predicate<Person> showSpecificPeoplePredicate = p -> p.hasModule(this.moduleCode);
+            model.updateFilteredPersonList(showSpecificPeoplePredicate);
+            return new CommandResult(MESSAGE_SUCCESS_MODULE);
+        case TYPE:
+            if (type.equals("professors")) {
+                model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PROFESSORS);
+            } else {
+                model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_STUDENTS);
+            }
+            return new CommandResult(MESSAGE_SUCCESS_TYPE);
+        case MODULEANDTYPE:
+            if (type.equals("professors")) {
+                Predicate<Person> showSpecificProfessorPredicate = p -> p.hasModule(this.moduleCode)
+                        && (p instanceof Professor);
+                model.updateFilteredPersonList(showSpecificProfessorPredicate);
+            } else {
+                Predicate<Person> showSpecificStudentPredicate = p -> p.hasModule(this.moduleCode)
+                        && (p instanceof Student);
+                model.updateFilteredPersonList(showSpecificStudentPredicate);
+            }
+            return new CommandResult(MESSAGE_SUCCESS_MODULEANDTYPE);
+        default:
+            return new CommandResult(MESSAGE_USAGE);
+        }
     }
 }

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
+import unibook.commons.core.Messages;
 import unibook.model.Model;
 import unibook.model.ModelManager;
 import unibook.model.module.Module;
@@ -12,6 +13,7 @@ import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
 import unibook.model.person.Professor;
 import unibook.model.person.Student;
+
 /**
  * Lists all persons in the UniBook according to the user specified criteria.
  */
@@ -27,10 +29,6 @@ public class ListCommand extends Command {
     public static final String MESSAGE_SUCCESS_MODULEANDTYPE = "Listed all persons with specified type "
             + "in specified module.";
     public static final String MESSAGE_SUCCESS_VIEW = "Switched view successfully.";
-
-    public static final String MESSAGE_MODULE_DOES_NOT_EXIST = "The module entered"
-            + " does not exist in the UniBook";
-
     public static final String MESSAGE_USAGE_TYPE = "The acceptable arguments for type are students/professors.";
     public static final String MESSAGE_WRONG_VIEW = "The command requires you to switch views.";
     public static final String MESSAGE_USAGE_OPTION = "The acceptable arguments for option are module/type.";
@@ -129,7 +127,7 @@ public class ListCommand extends Command {
             return new CommandResult(MESSAGE_SUCCESS);
         case MODULE:
             if (!moduleCodeExists(model.getUniBook().getModuleList())) {
-                return new CommandResult(MESSAGE_MODULE_DOES_NOT_EXIST);
+                return new CommandResult(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
             }
             if (modelManager.getUi().isPersonListShowing()) {
                 Predicate<Person> showSpecificPeoplePredicate = p -> p.hasModule(this.moduleCode);
@@ -158,7 +156,7 @@ public class ListCommand extends Command {
         case MODULEANDTYPE:
             if (modelManager.getUi().isPersonListShowing()) {
                 if (!moduleCodeExists(model.getUniBook().getModuleList())) {
-                    return new CommandResult(MESSAGE_MODULE_DOES_NOT_EXIST);
+                    return new CommandResult(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
                 }
                 if (type.equals("professors")) {
                     Predicate<Person> showSpecificProfessorPredicate = p -> p.hasModule(this.moduleCode)

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -31,12 +31,14 @@ public class ListCommand extends Command {
     public static final String MESSAGE_MODULE_DOES_NOT_EXIST = "The module entered"
             + " does not exist in the UniBook";
 
+    public static final String MESSAGE_USAGE_TYPE = "The acceptable arguments for type are students/professors.";
     public static final String MESSAGE_WRONG_VIEW = "The command requires you to switch views.";
+    public static final String MESSAGE_USAGE_OPTION = "The acceptable arguments for option are module/type.";
+    public static final String MESSAGE_TYPE_MISSING = "You did not enter a type argument. The acceptable"
+            + " arguments for type are students/professors.";
+    public static final String MESSAGE_MODULE_MISSING = "You did not enter a Module argument.";
+    public static final String MESSAGE_USAGE_VIEW = "The acceptable arguments for view are modules/people.";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Lists according to the given criteria\n "
-            + "Parameters: option (either module or type) \n"
-            + "Example: list o/module m/cs2103\n";
 
     private enum ListCommandType {
         ALL, MODULE, TYPE, MODULEANDTYPE, VIEW
@@ -143,8 +145,10 @@ public class ListCommand extends Command {
             if (modelManager.getUi().isPersonListShowing()) {
                 if (type.equals("professors")) {
                     model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PROFESSORS);
-                } else {
+                } else if (type.equals("students")) {
                     model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_STUDENTS);
+                } else {
+                    return new CommandResult(MESSAGE_USAGE_TYPE);
                 }
             } else {
                 return new CommandResult(MESSAGE_WRONG_VIEW);
@@ -160,16 +164,17 @@ public class ListCommand extends Command {
                     Predicate<Person> showSpecificProfessorPredicate = p -> p.hasModule(this.moduleCode)
                             && (p instanceof Professor);
                     model.updateFilteredPersonList(showSpecificProfessorPredicate);
-                } else {
+                } else if (type.equals("students")) {
                     Predicate<Person> showSpecificStudentPredicate = p -> p.hasModule(this.moduleCode)
                             && (p instanceof Student);
                     model.updateFilteredPersonList(showSpecificStudentPredicate);
+                } else {
+                    return new CommandResult(MESSAGE_USAGE_TYPE);
                 }
                 return new CommandResult(MESSAGE_SUCCESS_MODULEANDTYPE);
             } else {
                 return new CommandResult(MESSAGE_WRONG_VIEW);
             }
-
         case VIEW:
             if (this.viewType == ListView.MODULES) {
                 modelManager.getUi().setModuleListPanel();
@@ -178,7 +183,7 @@ public class ListCommand extends Command {
             }
             return new CommandResult(MESSAGE_SUCCESS_VIEW);
         default:
-            return new CommandResult(MESSAGE_USAGE);
+            return new CommandResult("");
         }
     }
 }

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.function.Predicate;
 
 import unibook.model.Model;
+import unibook.model.ModelManager;
 import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
 import unibook.model.person.Professor;
@@ -22,6 +23,7 @@ public class ListCommand extends Command {
     public static final String MESSAGE_SUCCESS_TYPE = "Listed all persons with specified type.";
     public static final String MESSAGE_SUCCESS_MODULEANDTYPE = "Listed all persons with specified type "
             + "in specified module.";
+    public static final String MESSAGE_SUCCESS_VIEW = "Switched view successfully.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists according to the given criteria\n "
@@ -29,18 +31,32 @@ public class ListCommand extends Command {
             + "Example: list o/module m/cs2103\n";
 
     private enum ListCommandType {
-        ALL, MODULE, TYPE, MODULEANDTYPE
+        ALL, MODULE, TYPE, MODULEANDTYPE, VIEW
+    };
+
+    public enum ListView {
+        PEOPLE, MODULES
     };
 
     private ModuleCode moduleCode;
     private String type;
     private ListCommandType commandType;
+    private ListView viewType;
 
     /**
      * Constructor for a ListCommand to list everything.
      */
     public ListCommand() {
         this.commandType = ListCommandType.ALL;
+    }
+
+    /**
+     * Constructor for a ListCommand to change the current view.
+     * @param viewType
+     */
+    public ListCommand(ListView viewType) {
+        this.commandType = ListCommandType.VIEW;
+        this.viewType = viewType;
     }
 
     /**
@@ -113,6 +129,14 @@ public class ListCommand extends Command {
                 model.updateFilteredPersonList(showSpecificStudentPredicate);
             }
             return new CommandResult(MESSAGE_SUCCESS_MODULEANDTYPE);
+        case VIEW:
+            ModelManager modelManager = (ModelManager) model;
+            if (this.viewType == ListView.MODULES) {
+                modelManager.getUi().setModuleListPanel();
+            } else {
+                modelManager.getUi().setPersonListPanel();
+            }
+            return new CommandResult(MESSAGE_SUCCESS_VIEW);
         default:
             return new CommandResult(MESSAGE_USAGE);
         }

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import unibook.commons.core.Messages;
+import unibook.logic.commands.exceptions.CommandException;
 import unibook.model.Model;
 import unibook.model.ModelManager;
 import unibook.model.module.Module;
@@ -118,7 +119,7 @@ public class ListCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, Boolean isPersonListShowing,
-                                 Boolean isModuleListShowing) {
+                                 Boolean isModuleListShowing) throws CommandException {
         requireNonNull(model);
         showAll(model);
         ModelManager modelManager = (ModelManager) model;
@@ -127,7 +128,7 @@ public class ListCommand extends Command {
             return new CommandResult(MESSAGE_SUCCESS);
         case MODULE:
             if (!moduleCodeExists(model.getUniBook().getModuleList())) {
-                return new CommandResult(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
+                throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
             }
             if (modelManager.getUi().isPersonListShowing()) {
                 Predicate<Person> showSpecificPeoplePredicate = p -> p.hasModule(this.moduleCode);
@@ -156,7 +157,7 @@ public class ListCommand extends Command {
         case MODULEANDTYPE:
             if (modelManager.getUi().isPersonListShowing()) {
                 if (!moduleCodeExists(model.getUniBook().getModuleList())) {
-                    return new CommandResult(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
+                    throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
                 }
                 if (type.equals("professors")) {
                     Predicate<Person> showSpecificProfessorPredicate = p -> p.hasModule(this.moduleCode)

--- a/src/main/java/unibook/logic/parser/CliSyntax.java
+++ b/src/main/java/unibook/logic/parser/CliSyntax.java
@@ -15,4 +15,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_NEWMOD = new Prefix("nm/");
     public static final Prefix PREFIX_OFFICE = new Prefix("a/");
     public static final Prefix PREFIX_TYPE = new Prefix("ty/");
+    public static final Prefix PREFIX_VIEW = new Prefix("v/");
 }

--- a/src/main/java/unibook/logic/parser/CliSyntax.java
+++ b/src/main/java/unibook/logic/parser/CliSyntax.java
@@ -14,4 +14,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_MODULE = new Prefix("m/");
     public static final Prefix PREFIX_NEWMOD = new Prefix("nm/");
     public static final Prefix PREFIX_OFFICE = new Prefix("a/");
+    public static final Prefix PREFIX_TYPE = new Prefix("ty/");
 }

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -56,6 +56,7 @@ public class ListCommandParser implements Parser<ListCommand> {
 
                 ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(CliSyntax.PREFIX_MODULE).get()
                     .toUpperCase());
+
                 if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
                     String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
                     if (!(type.equals("professors") || type.equals("students"))) {

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -25,7 +25,22 @@ public class ListCommandParser implements Parser<ListCommand> {
         try {
             ArgumentMultimap argMultimap =
                     ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_OPTION, CliSyntax.PREFIX_TYPE,
-                            CliSyntax.PREFIX_MODULE);
+                            CliSyntax.PREFIX_MODULE, CliSyntax.PREFIX_VIEW);
+
+            //Change View command
+            if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_VIEW)) {
+                String view = argMultimap.getValue(CliSyntax.PREFIX_VIEW).get().toLowerCase();
+                if (view.equals("modules")) {
+                    return new ListCommand(ListCommand.ListView.MODULES);
+                } else if (view.equals("people")) {
+                    return new ListCommand(ListCommand.ListView.PEOPLE);
+                } else {
+                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            ListCommand.MESSAGE_USAGE));
+                }
+            }
+
+            //List all (empty list command)
             if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_OPTION)) {
                 return new ListCommand();
             }

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -58,6 +58,10 @@ public class ListCommandParser implements Parser<ListCommand> {
                     .toUpperCase());
                 if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
                     String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
+                    if (!(type.equals("professors") || type.equals("students"))) {
+                        throw new ParseException(
+                                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE_TYPE));
+                    }
                     return new ListCommand(moduleCode, type);
                 } else {
                     return new ListCommand(moduleCode);

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -1,0 +1,75 @@
+package unibook.logic.parser;
+
+import java.util.stream.Stream;
+
+import unibook.commons.core.Messages;
+import unibook.logic.commands.ListCommand;
+import unibook.logic.parser.exceptions.ParseException;
+import unibook.model.module.ModuleCode;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListCommand
+     * and returns a ListCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+        try {
+            ArgumentMultimap argMultimap =
+                    ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_OPTION, CliSyntax.PREFIX_TYPE,
+                            CliSyntax.PREFIX_MODULE);
+            if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_OPTION)) {
+                return new ListCommand();
+            }
+
+            String option = argMultimap.getValue(CliSyntax.PREFIX_OPTION).get();
+
+            switch (option) {
+            case "module":
+                if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
+                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            ListCommand.MESSAGE_USAGE));
+                }
+
+                ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(CliSyntax.PREFIX_MODULE).get()
+                    .toUpperCase());
+                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
+                    String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
+                    return new ListCommand(moduleCode, type);
+                } else {
+                    return new ListCommand(moduleCode);
+                }
+            case "type":
+                if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
+                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            ListCommand.MESSAGE_USAGE));
+                }
+                String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
+                if (type.equals("students") || type.equals("professors")) {
+                    return new ListCommand(type);
+                } else {
+                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            ListCommand.MESSAGE_USAGE));
+                }
+            default:
+                throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                        ListCommand.MESSAGE_USAGE));
+
+
+            }
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), pe);
+        }
+
+    }
+
+}

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -36,7 +36,7 @@ public class ListCommandParser implements Parser<ListCommand> {
                     return new ListCommand(ListCommand.ListView.PEOPLE);
                 } else {
                     throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            ListCommand.MESSAGE_USAGE));
+                            ListCommand.MESSAGE_USAGE_VIEW));
                 }
             }
 
@@ -51,7 +51,7 @@ public class ListCommandParser implements Parser<ListCommand> {
             case "module":
                 if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
                     throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            ListCommand.MESSAGE_USAGE));
+                            ListCommand.MESSAGE_MODULE_MISSING));
                 }
 
                 ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(CliSyntax.PREFIX_MODULE).get()
@@ -65,24 +65,21 @@ public class ListCommandParser implements Parser<ListCommand> {
             case "type":
                 if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
                     throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            ListCommand.MESSAGE_USAGE));
+                            ListCommand.MESSAGE_TYPE_MISSING));
                 }
                 String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
-                if (type.equals("students") || type.equals("professors")) {
-                    return new ListCommand(type);
-                } else {
-                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            ListCommand.MESSAGE_USAGE));
+                if (!(type.equals("professors") || type.equals("students"))) {
+                    throw new ParseException(
+                            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE_TYPE));
                 }
+                return new ListCommand(type);
             default:
                 throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                        ListCommand.MESSAGE_USAGE));
-
+                        ListCommand.MESSAGE_USAGE_OPTION));
 
             }
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), pe);
+            throw pe;
         }
 
     }

--- a/src/main/java/unibook/logic/parser/UniBookParser.java
+++ b/src/main/java/unibook/logic/parser/UniBookParser.java
@@ -65,7 +65,7 @@ public class UniBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/unibook/model/Model.java
+++ b/src/main/java/unibook/model/Model.java
@@ -138,4 +138,5 @@ public interface Model {
     ObservableList<Module> getFilteredModuleList();
 
     void updateFilteredModuleList(Predicate<Module> predicate);
+
 }

--- a/src/main/java/unibook/model/Model.java
+++ b/src/main/java/unibook/model/Model.java
@@ -8,6 +8,8 @@ import unibook.commons.core.GuiSettings;
 import unibook.model.module.Module;
 import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
+import unibook.model.person.Professor;
+import unibook.model.person.Student;
 
 
 /**
@@ -19,6 +21,9 @@ public interface Model {
      */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
     Predicate<Module> PREDICATE_SHOW_ALL_MODULES = unused -> true;
+
+    Predicate<Person> PREDICATE_SHOW_ALL_PROFESSORS = p -> p instanceof Professor;
+    Predicate<Person> PREDICATE_SHOW_ALL_STUDENTS = p -> p instanceof Student;
 
     /**
      * Returns the user prefs.

--- a/src/main/java/unibook/model/ModelManager.java
+++ b/src/main/java/unibook/model/ModelManager.java
@@ -16,6 +16,8 @@ import unibook.model.module.Module;
 import unibook.model.module.ModuleCode;
 import unibook.model.person.Person;
 import unibook.model.person.exceptions.PersonNoSubtypeException;
+import unibook.ui.Ui;
+import unibook.ui.UiManager;
 
 
 /**
@@ -28,6 +30,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Module> filteredModules;
+    private Ui ui;
 
     /**
      * Initializes a ModelManager with the given uniBook and userPrefs.
@@ -220,6 +223,14 @@ public class ModelManager implements Model {
         logger.info("Updating filtered module list...");
         requireNonNull(predicate);
         filteredModules.setPredicate(predicate);
+    }
+
+    public void setUi(Ui ui) {
+        this.ui = ui;
+    }
+
+    public UiManager getUi() {
+        return (UiManager) this.ui;
     }
 
     @Override

--- a/src/main/java/unibook/model/person/Person.java
+++ b/src/main/java/unibook/model/person/Person.java
@@ -128,6 +128,19 @@ public class Person {
     }
 
     /**
+     * Returns true if the specified Module exists in the person's
+     * module list, otherwise returns false.
+     */
+    public boolean hasModule(ModuleCode moduleCode) {
+        for (Module m : modules) {
+            if (m.hasModuleCode(moduleCode)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Adds a module to the module set
      */
     public void addModule(Module module) {

--- a/src/main/java/unibook/ui/UiManager.java
+++ b/src/main/java/unibook/ui/UiManager.java
@@ -90,6 +90,15 @@ public class UiManager implements Ui {
         return mainWindow.isModuleListShowing();
     }
 
+
+    public void setModuleListPanel() {
+        mainWindow.setModuleListPanel();
+    }
+
+    public void setPersonListPanel() {
+        mainWindow.setPersonListPanel();
+    }
+
     private Image getImage(String imagePath) {
         return new Image(MainApp.class.getResourceAsStream(imagePath));
     }


### PR DESCRIPTION
- Added functionality to display specified criteria when `Persons` are being shown. 
- The functionality to display specified `Module` is currently not done as it is still not totally clear how we want that to work, but adding it should be trivial later on.
- Please follow the following format for the commands instead of the User Guide (as user guide includes those for groups)

- `list` (works in both views)
Lists all persons or all modules depending on the currently active view.

- `list o/module m/<MODULECODE>` (Works in both views)
Lists all people associated with a specified module.
Example: `list o/module m/CS2103` will list all people associated with the module `CS2103`.

- `list o/type ty/<TYPE>` (Works only in person view)
Lists all people with a specified type.
Example: `list o/type ty/professors` will list all professors. `list o/type ty/students` will list all students.

- `list o/module m/<MODULECODE> ty/<TYPE>` (Works only in person view)
Lists all people with a specified type, in a specified module.
Example: `list o/module m/CS2103 ty/students` will list all students in module `CS2103`.

- `list v/<VIEWTYPE>` (Works in both views)
Switches the view according to `VIEWTYPE`.
Example: `list v/modules` switches the UniBook to module-view.
`list v/people` switches the UniBook to people-view.

Do let me know if you encounter any problems. Thank you!