### PR TITLE
Fix AddCommandParser and AddCommand

### DIFF
--- a/src/main/java/unibook/logic/commands/AddCommand.java
+++ b/src/main/java/unibook/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package unibook.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import unibook.logic.commands.exceptions.CommandException;
@@ -112,6 +113,7 @@ public class AddCommand extends Command {
 
     private Person personToAdd = new Person();
     private Module moduleToAdd = new Module();
+    private Set<ModuleCode> moduleCodeSet = new HashSet<>();
 
     /**
      * Creates an AddCommand to add the specified {@code Person}
@@ -119,6 +121,15 @@ public class AddCommand extends Command {
     public AddCommand(Person person) {
         requireNonNull(person);
         personToAdd = person;
+    }
+
+    /**
+     * Creates an AddCommand to add the specified {@code Person} with {@code moduleCodes}
+     */
+    public AddCommand(Person person, Set<ModuleCode> moduleCodes) {
+        requireNonNull(person);
+        personToAdd = person;
+        moduleCodeSet = moduleCodes;
     }
 
     /**
@@ -146,12 +157,11 @@ public class AddCommand extends Command {
         } else {
             if (model.hasPerson(personToAdd)) {
                 throw new CommandException(MESSAGE_DUPLICATE_PERSON);
-            } else if (!model.isModuleExist(personToAdd)) {
+            } else if (!model.isModuleExist(moduleCodeSet)) {
                 throw new CommandException(MESSAGE_MODULE_DOES_NOT_EXIST);
             }
-            Set<ModuleCode> personModuleCodes = personToAdd.getModuleCodes();
             Set<Module> personModules = personToAdd.getModulesModifiable();
-            for (ModuleCode moduleCode : personModuleCodes) {
+            for (ModuleCode moduleCode : moduleCodeSet) {
                 Module toAdd = model.getModuleByCode(moduleCode);
                 personModules.add(toAdd);
             }

--- a/src/main/java/unibook/logic/parser/AddCommandParser.java
+++ b/src/main/java/unibook/logic/parser/AddCommandParser.java
@@ -79,8 +79,8 @@ public class AddCommandParser implements Parser<AddCommand> {
             email = ParserUtil.parseEmail(argMultimap.getValue(CliSyntax.PREFIX_EMAIL).get());
             tagList = ParserUtil.parseTags(argMultimap.getAllValues(CliSyntax.PREFIX_TAG));
             moduleCodes = ParserUtil.parseMultipleModules(argMultimap.getAllValues(CliSyntax.PREFIX_MODULE));
-            Student student = new Student(name, phone, email, tagList, moduleList, moduleCodes);
-            return new AddCommand(student);
+            Student student = new Student(name, phone, email, tagList, moduleList);
+            return new AddCommand(student, moduleCodes);
         case "professor":
             if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_PHONE,
                     CliSyntax.PREFIX_EMAIL, CliSyntax.PREFIX_OFFICE)) {
@@ -93,8 +93,12 @@ public class AddCommandParser implements Parser<AddCommand> {
             office = ParserUtil.parseOffice(argMultimap.getValue(CliSyntax.PREFIX_OFFICE).get());
             tagList = ParserUtil.parseTags(argMultimap.getAllValues(CliSyntax.PREFIX_TAG));
             moduleCodes = ParserUtil.parseMultipleModules(argMultimap.getAllValues(CliSyntax.PREFIX_MODULE));
-            Professor professor = new Professor(name, phone, email, tagList, office, moduleList, moduleCodes);
-            return new AddCommand(professor);
+            Professor professor = new Professor(name, phone, email, tagList, office, moduleList);
+            if (moduleCodes.isEmpty()) {
+                return new AddCommand(professor);
+            } else {
+                return new AddCommand(professor, moduleCodes);
+            }
         default:
             throw new ParseException(MESSAGE_CONSTRAINTS_OPTION);
         }

--- a/src/main/java/unibook/model/Model.java
+++ b/src/main/java/unibook/model/Model.java
@@ -1,6 +1,7 @@
 package unibook.model;
 
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -127,7 +128,7 @@ public interface Model {
 
     void setModule(Module target, Module editedModule);
 
-    boolean isModuleExist(Person person);
+    boolean isModuleExist(Set<ModuleCode> moduleCodeSet);
 
     /**
      * Finds the corresponding module to the module code.

--- a/src/main/java/unibook/model/ModelManager.java
+++ b/src/main/java/unibook/model/ModelManager.java
@@ -117,7 +117,7 @@ public class ModelManager implements Model {
     @Override
     public void addPersonToTheirModules(Person person) {
         try {
-            uniBook.addPersonToAllTheirModuleCodes(person);
+            uniBook.addPersonToAllTheirModules(person);
         } catch (PersonNoSubtypeException e) {
             e.printStackTrace();
         }
@@ -178,9 +178,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean isModuleExist(Person person) {
-        Set<ModuleCode> moduleCodes = person.getModuleCodes();
-        for (ModuleCode moduleCode : moduleCodes) {
+    public boolean isModuleExist(Set<ModuleCode> moduleCodeSet) {
+        for (ModuleCode moduleCode : moduleCodeSet) {
             if (!uniBook.hasModule(moduleCode)) {
                 return false;
             }

--- a/src/main/java/unibook/model/UniBook.java
+++ b/src/main/java/unibook/model/UniBook.java
@@ -115,26 +115,6 @@ public class UniBook implements ReadOnlyUniBook {
     }
 
     /**
-     * Adds this person to all the module codes that they are associated with, into the
-     * correct personnel list (professor/student) in module depending on the runtime type
-     * of this person.
-     *
-     * @param p person whos modules to add them to
-     */
-    public void addPersonToAllTheirModuleCodes(Person p) throws PersonNoSubtypeException {
-        for (ModuleCode personsModuleCodes : p.getModuleCodes()) {
-            Module module = modules.getModuleByCode(personsModuleCodes);
-            if (p instanceof Student) {
-                module.addStudent((Student) p);
-            } else if (p instanceof Professor) {
-                module.addProfessor((Professor) p);
-            } else {
-                throw new PersonNoSubtypeException();
-            }
-        }
-    }
-
-    /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the UniBook.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the UniBook.

--- a/src/main/java/unibook/model/person/Person.java
+++ b/src/main/java/unibook/model/person/Person.java
@@ -28,9 +28,6 @@ public class Person {
     // Data fields
     private final Set<Tag> tags = new HashSet<>();
 
-    // Temporary field to store module codes that a person is associated with.
-    private final Set<ModuleCode> moduleCodes = new HashSet<>();
-
     /**
      * Every field must be present and not null.
      */
@@ -41,20 +38,6 @@ public class Person {
         this.phone = phone;
         this.tags.addAll(tags);
         this.modules.addAll(modules);
-    }
-
-    /**
-     * Constructor of Person with extra ModuleCode parameter.
-     */
-    public Person(Name name, Phone phone, Email email, Set<Tag> tags,
-                  Set<Module> modules, Set<ModuleCode> moduleCodes) {
-        CollectionUtil.requireAllNonNull(name, phone, email, tags);
-        this.name = name;
-        this.email = email;
-        this.phone = phone;
-        this.tags.addAll(tags);
-        this.modules.addAll(modules);
-        this.moduleCodes.addAll(moduleCodes);
     }
 
     /**
@@ -135,14 +118,6 @@ public class Person {
      */
     public Set<Module> getModulesModifiable() {
         return modules;
-    }
-
-    /**
-     * Returns an immutable modulecode set, which throws {@code UnsupportedOperationException}
-     * if modification is attempted.
-     */
-    public Set<ModuleCode> getModuleCodes() {
-        return Collections.unmodifiableSet(moduleCodes);
     }
 
     /**

--- a/src/main/java/unibook/model/person/Professor.java
+++ b/src/main/java/unibook/model/person/Professor.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import unibook.model.module.Module;
-import unibook.model.module.ModuleCode;
 import unibook.model.tag.Tag;
 
 /**
@@ -20,15 +19,6 @@ public class Professor extends Person {
      */
     public Professor(Name name, Phone phone, Email email, Set<Tag> tags, Office office, Set<Module> modules) {
         super(name, phone, email, tags, modules);
-        this.office = office;
-    }
-
-    /**
-     * Every field must be present and not null.
-     */
-    public Professor(Name name, Phone phone, Email email, Set<Tag> tags, Office office,
-                     Set<Module> modules, Set<ModuleCode> moduleCodes) {
-        super(name, phone, email, tags, modules, moduleCodes);
         this.office = office;
     }
 

--- a/src/main/java/unibook/model/person/Student.java
+++ b/src/main/java/unibook/model/person/Student.java
@@ -4,7 +4,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import unibook.model.module.Module;
-import unibook.model.module.ModuleCode;
 import unibook.model.tag.Tag;
 
 /**
@@ -18,14 +17,6 @@ public class Student extends Person {
      */
     public Student(Name name, Phone phone, Email email, Set<Tag> tags, Set<Module> modules) {
         super(name, phone, email, tags, modules);
-    }
-
-    /**
-     * Every field must be present and not null.
-     */
-    public Student(Name name, Phone phone, Email email, Set<Tag> tags,
-                   Set<Module> modules, Set<ModuleCode> moduleCodes) {
-        super(name, phone, email, tags, modules, moduleCodes);
     }
 
     /**

--- a/src/test/java/unibook/logic/commands/AddCommandTest.java
+++ b/src/test/java/unibook/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -203,7 +204,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean isModuleExist(Person person) {
+        public boolean isModuleExist(Set<ModuleCode> moduleCodeSet) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -265,8 +266,8 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean isModuleExist(Person person) {
-            requireNonNull(person);
+        public boolean isModuleExist(Set<ModuleCode> moduleCodeSet) {
+            requireNonNull(moduleCodeSet);
             return true;
         }
 


### PR DESCRIPTION
Removed the temporary field of ModuleCode from Person.

Able to add a Person object to Module and a Module object to a Person without the temporary field now.