### PR TITLE
Add KeyEvent functionality to Add Command

### DIFF
--- a/src/main/java/unibook/logic/commands/AddCommand.java
+++ b/src/main/java/unibook/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package unibook.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -13,7 +14,7 @@ import unibook.logic.parser.CliSyntax;
 import unibook.model.Model;
 import unibook.model.module.Module;
 import unibook.model.module.ModuleCode;
-import unibook.model.module.ModuleName;
+import unibook.model.module.ModuleKeyEvent;
 import unibook.model.module.group.Group;
 import unibook.model.person.Person;
 import unibook.model.person.Student;
@@ -26,7 +27,7 @@ public class AddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ": Adds a student/professor/module/group to the UniBook, depending on the option specified.\n"
+        + ": Adds a student/professor/module/group/event to the UniBook, depending on the option specified.\n"
         + "Parameters: "
         + CliSyntax.PREFIX_OPTION + "OPTION "
         + CliSyntax.PREFIX_NAME + "NAME "
@@ -35,7 +36,9 @@ public class AddCommand extends Command {
         + "[" + CliSyntax.PREFIX_OFFICE + "OFFICE] "
         + "[" + CliSyntax.PREFIX_TAG + "TAG]... "
         + "[" + CliSyntax.PREFIX_MODULE + "MODULE]... "
-        + "[" + CliSyntax.PREFIX_GROUP + "GROUP]...\n"
+        + "[" + CliSyntax.PREFIX_GROUP + "GROUP]... "
+        + "[" + CliSyntax.PREFIX_KEYEVENT + "TYPE] "
+        + "[" + CliSyntax.PREFIX_DATETIME + "DATETIME]\n"
         + "Example: " + COMMAND_WORD + " "
         + CliSyntax.PREFIX_OPTION + "student "
         + CliSyntax.PREFIX_NAME + "John Doe "
@@ -62,17 +65,26 @@ public class AddCommand extends Command {
         + "Example: " + COMMAND_WORD + " "
         + CliSyntax.PREFIX_OPTION + "group "
         + CliSyntax.PREFIX_NAME + "Study Group "
-        + CliSyntax.PREFIX_MODULE + "CS2100\n";
+        + CliSyntax.PREFIX_MODULE + "CS2100\n"
+        + "Example: " + COMMAND_WORD + " "
+        + CliSyntax.PREFIX_OPTION + "event "
+        + CliSyntax.PREFIX_MODULE + "CS2100 "
+        + CliSyntax.PREFIX_KEYEVENT + "1 "
+        + CliSyntax.PREFIX_DATETIME + "2022-05-04 13:00\n";
     public static final String MESSAGE_USAGE_MODULE = COMMAND_WORD
         + ": To add a module to the UniBook, use the following format.\n"
         + "Parameters: "
         + CliSyntax.PREFIX_OPTION + "module "
         + CliSyntax.PREFIX_NAME + "NAME "
-        + CliSyntax.PREFIX_MODULE + "MODULE\n"
+        + CliSyntax.PREFIX_MODULE + "MODULE "
+        + CliSyntax.PREFIX_KEYEVENT + "TYPE "
+        + CliSyntax.PREFIX_DATETIME + "DATETIME\n"
         + "Example: " + COMMAND_WORD + " "
         + CliSyntax.PREFIX_OPTION + "module "
         + CliSyntax.PREFIX_NAME + "Computer Organisation "
-        + CliSyntax.PREFIX_MODULE + "CS2100\n";
+        + CliSyntax.PREFIX_MODULE + "CS2100 "
+        + CliSyntax.PREFIX_KEYEVENT + "1 "
+        + CliSyntax.PREFIX_DATETIME + "2022-05-04 13:00\n";
     public static final String MESSAGE_USAGE_GROUP = COMMAND_WORD
         + ": To add a group to the UniBook, use the following format.\n"
         + "Parameters: "
@@ -133,6 +145,18 @@ public class AddCommand extends Command {
         + CliSyntax.PREFIX_MODULE + "CS2103 "
         + CliSyntax.PREFIX_MODULE + "CS2105 "
         + CliSyntax.PREFIX_GROUP + "CS2103 G16\n";
+    public static final String MESSAGE_USAGE_EVENT = COMMAND_WORD
+        + ": To add a key event to a module, use the following format.\n"
+        + "Parameters: "
+        + CliSyntax.PREFIX_OPTION + "event "
+        + CliSyntax.PREFIX_MODULE + "MODULE "
+        + CliSyntax.PREFIX_KEYEVENT + "TYPE "
+        + CliSyntax.PREFIX_DATETIME + "DATETIME\n"
+        + "Example: " + COMMAND_WORD + " "
+        + CliSyntax.PREFIX_OPTION + "event "
+        + CliSyntax.PREFIX_MODULE + "CS2100 "
+        + CliSyntax.PREFIX_KEYEVENT + "1 "
+        + CliSyntax.PREFIX_DATETIME + "2022-05-04 13:00\n";
 
     public static final String MESSAGE_SUCCESS_PERSON = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the UniBook";
@@ -143,6 +167,9 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS_GROUP = "New group added: %1$s";
     public static final String MESSAGE_DUPLICATE_GROUP = "This group already exists in the specified"
         + "module in the UniBook";
+
+    public static final String MESSAGE_SUCCESS_EVENT = "New event added: %1$s";
+    public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the module specified.";
 
     public static final String MESSAGE_MODULE_DOES_NOT_EXIST = "One or more of the modules entered"
         + " does not exist in the UniBook";
@@ -156,6 +183,8 @@ public class AddCommand extends Command {
     private ModuleCode moduleCode;
     private Set<ModuleCode> moduleCodeSet = new HashSet<>();
     private ArrayList<LinkedHashSet<String>> groupNamesList;
+    private ModuleKeyEvent.KeyEventType keyEvent;
+    private LocalDateTime dateTime;
 
     /**
      * Creates an AddCommand to add the specified {@code Person}
@@ -187,11 +216,19 @@ public class AddCommand extends Command {
     /**
      * Creates an AddCommand to add the specified {@code Module}
      */
-    public AddCommand(ModuleName moduleName, ModuleCode moduleCode) {
-        requireNonNull(moduleName);
-        requireNonNull(moduleCode);
-        Module module = new Module(moduleName, moduleCode);
+    public AddCommand(Module module) {
+        requireNonNull(module);
         moduleToAdd = module;
+    }
+
+    /**
+     * Creates an AddCommand to add the specified {@code Module}
+     */
+    public AddCommand(ModuleCode moduleCode, ModuleKeyEvent.KeyEventType keyEvent, LocalDateTime dateTime) {
+        requireNonNull(moduleCode);
+        this.moduleCode = moduleCode;
+        this.keyEvent = keyEvent;
+        this.dateTime = dateTime;
     }
 
     /**
@@ -253,6 +290,17 @@ public class AddCommand extends Command {
             }
             model.addPerson(personToAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS_PERSON, personToAdd));
+        } else if (keyEvent != null) {
+            if (!model.hasModule(moduleCode)) {
+                throw new CommandException(MESSAGE_MODULE_DOES_NOT_EXIST);
+            }
+            Module moduleToAddEventTo = model.getModuleByCode(moduleCode);
+            if (moduleToAddEventTo.hasEvent(keyEvent, dateTime)) {
+                throw new CommandException(MESSAGE_DUPLICATE_EVENT);
+            }
+            ModuleKeyEvent moduleKeyEvent = new ModuleKeyEvent(keyEvent, dateTime, moduleToAddEventTo);
+            moduleToAddEventTo.addKeyEvent(moduleKeyEvent);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_EVENT, moduleKeyEvent));
         } else {
             if (!model.hasModule(moduleCode)) {
                 throw new CommandException(MESSAGE_MODULE_DOES_NOT_EXIST);

--- a/src/main/java/unibook/logic/parser/CliSyntax.java
+++ b/src/main/java/unibook/logic/parser/CliSyntax.java
@@ -17,4 +17,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TYPE = new Prefix("ty/");
     public static final Prefix PREFIX_VIEW = new Prefix("v/");
     public static final Prefix PREFIX_GROUP = new Prefix("g/");
+    public static final Prefix PREFIX_KEYEVENT = new Prefix("ke/");
+    public static final Prefix PREFIX_MEETINGTIME = new Prefix("mt/");
+    public static final Prefix PREFIX_DATETIME = new Prefix("dt/");
 }

--- a/src/main/java/unibook/logic/parser/ParserUtil.java
+++ b/src/main/java/unibook/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package unibook.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -14,6 +16,7 @@ import unibook.commons.util.StringUtil;
 import unibook.logic.parser.exceptions.ParseException;
 import unibook.model.module.Module;
 import unibook.model.module.ModuleCode;
+import unibook.model.module.ModuleKeyEvent;
 import unibook.model.module.ModuleName;
 import unibook.model.person.Email;
 import unibook.model.person.Name;
@@ -239,5 +242,65 @@ public class ParserUtil {
             groupList.add(groupNamesSet);
         }
         return groupList;
+    }
+
+    /**
+     * Parses {@code Collection<String> keyEventAndDate} and
+     * {@code Module module}into a {@code ArrayList<ModuleKeyEvent>}.
+     */
+    public static ArrayList<ModuleKeyEvent> parseModuleKeyEvent(Collection<String> keyEventAndDate, Module module)
+            throws ParseException {
+        requireNonNull(keyEventAndDate);
+        final ArrayList<ModuleKeyEvent> moduleKeyEventList = new ArrayList<>();
+        if (keyEventAndDate.toArray().length == 0) {
+            return moduleKeyEventList;
+        }
+        for (String eventAndDate : keyEventAndDate) {
+            try {
+                String[] strArr = eventAndDate.split(" dt/");
+                LocalDateTime dateTime = parseDateTime(strArr[1]);
+                ModuleKeyEvent.KeyEventType keyEventType = parseKeyEventType(strArr[0]);
+                ModuleKeyEvent moduleKeyEvent = new ModuleKeyEvent(keyEventType, dateTime, module);
+                moduleKeyEventList.add(moduleKeyEvent);
+            } catch (Exception e) {
+                throw new ParseException(ModuleKeyEvent.MESSAGE_CONSTRAINTS_MISSINGDT);
+            }
+        }
+        return moduleKeyEventList;
+    }
+
+    /**
+     * Parses {@code String dateTime} into a {@code LocalDateTime}.
+     */
+    public static LocalDateTime parseDateTime(String dateTime) throws ParseException {
+        requireNonNull(dateTime);
+        String trimmedDateTime = dateTime.trim();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        try {
+            return LocalDateTime.parse(trimmedDateTime, formatter);
+        } catch (Exception e) {
+            throw new ParseException("DateTime format accepts the following:\n"
+                + "yyyy-MM-dd HH:mm");
+        }
+    }
+
+    /**
+     * Parses {@code String keyEventType} into a {@code KeyEventType}.
+     */
+    public static ModuleKeyEvent.KeyEventType parseKeyEventType(String keyEventType) throws ParseException {
+        requireNonNull(keyEventType);
+        String keyEventTypeTrimmed = keyEventType.trim();
+        switch (keyEventTypeTrimmed) {
+        case "1":
+            return ModuleKeyEvent.KeyEventType.EXAM;
+        case "2":
+            return ModuleKeyEvent.KeyEventType.QUIZ;
+        case "3":
+            return ModuleKeyEvent.KeyEventType.ASSIGNMENT_RELEASE;
+        case "4":
+            return ModuleKeyEvent.KeyEventType.ASSIGNMENT_DUE;
+        default:
+            throw new ParseException(ModuleKeyEvent.MESSAGE_CONSTRAINTS_TYPE);
+        }
     }
 }

--- a/src/main/java/unibook/model/module/Module.java
+++ b/src/main/java/unibook/model/module/Module.java
@@ -3,6 +3,8 @@ package unibook.model.module;
 import static java.util.Objects.requireNonNull;
 import static unibook.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Objects;
 
 import javafx.collections.FXCollections;
@@ -65,6 +67,23 @@ public class Module {
         this.students = FXCollections.observableArrayList();
         this.professors = FXCollections.observableArrayList();
         this.keyEvents = FXCollections.observableArrayList();
+    }
+
+    /**
+     * Constructor for a Module, using a pre-existing list of key dates.
+     *
+     * @param moduleName
+     * @param moduleCode
+     * @param keyEvents
+     */
+    public Module(ObservableList<ModuleKeyEvent> keyEvents, ModuleName moduleName, ModuleCode moduleCode) {
+        requireAllNonNull(moduleName, moduleCode, keyEvents);
+        this.moduleName = moduleName;
+        this.moduleCode = moduleCode;
+        this.groups = FXCollections.observableArrayList();
+        this.students = FXCollections.observableArrayList();
+        this.professors = FXCollections.observableArrayList();
+        this.keyEvents = keyEvents;
     }
 
     /**
@@ -224,7 +243,7 @@ public class Module {
     /**
      * Adds key event to the correct module.
      *
-     * @param k
+     * @param k ModuleKeyEvent
      */
     public void addKeyEvent(ModuleKeyEvent k) {
         requireNonNull(k);
@@ -232,6 +251,21 @@ public class Module {
             throw new DuplicateKeyEventException();
         }
         keyEvents.add(k);
+    }
+
+    /**
+     * Adds a list of key events to the correct module.
+     *
+     * @param keyEventsList ArrayList of ModuleKeyEvent
+     */
+    public void addKeyEventList(ArrayList<ModuleKeyEvent> keyEventsList) {
+        requireNonNull(keyEventsList);
+        for (ModuleKeyEvent moduleKeyEvent : keyEventsList) {
+            if (keyEvents.contains(moduleKeyEvent)) {
+                throw new DuplicateKeyEventException();
+            }
+            keyEvents.add(moduleKeyEvent);
+        }
     }
 
     /**
@@ -268,6 +302,23 @@ public class Module {
     public boolean hasGroupName(String groupName) {
         for (Group group : groups) {
             if (group.getGroupName().equals(groupName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns rue if this module contains the key event with the given event name and datetime.
+     *
+     * @param keyEvent key event name to check
+     * @param dateTime datetime of key event to check
+     * @return boolean variable indicating if the key event exists in this module
+     */
+    public boolean hasEvent(ModuleKeyEvent.KeyEventType keyEvent, LocalDateTime dateTime) {
+        for (ModuleKeyEvent moduleKeyEvent : keyEvents) {
+            if (moduleKeyEvent.getKeyEventType().equals(keyEvent)
+                    && moduleKeyEvent.getKeyEventTiming().equals(dateTime)) {
                 return true;
             }
         }
@@ -349,5 +400,4 @@ public class Module {
             .append(getKeyEvents());
         return builder.toString();
     }
-
 }

--- a/src/main/java/unibook/model/module/ModuleKeyEvent.java
+++ b/src/main/java/unibook/model/module/ModuleKeyEvent.java
@@ -6,6 +6,11 @@ import java.time.LocalDateTime;
 
 
 public class ModuleKeyEvent {
+    public static final String MESSAGE_CONSTRAINTS_TYPE = "Key Event type can only take in values from 1 to 4.\n"
+            + "1 = EXAM\n2 = QUIZ\n3 = ASSIGNMENT_RELEASE\n4 = ASSIGNMENT_DUE";
+    public static final String MESSAGE_CONSTRAINTS_MISSINGDT = "Missing datetime field in your input."
+            + "Please specify the date and time of the key event in the following format!\n"
+            + "dt/yyyy-MM-dd HH:mm";
     private LocalDateTime keyEventTiming;
     private KeyEventType keyEventType;
     private Module module;


### PR DESCRIPTION
User can now add Key Event to new/existing module using the following format. Please note the following: 
TYPE is accepting value between 1 - 4.
DATETIME format is currently only accepting `yyyy-MM-dd HH:mm`.
User can only add 1 Key Event to a module at a time.

<html>
<body>
<!--StartFragment--><b style="font-weight:normal;" id="docs-internal-guid-a382d8d6-7fff-2573-8f50-83cb85bee095"><div dir="ltr" style="margin-left:0pt;" align="left">

Adding a new module with keyevent | `add o/module n/MODULENAME m/MODULECODE ke/TYPE dt/DATETIME`  E.g. `add o/module n/Software Engineering m/CS2103 ke/1 dt/2022-05-04 13:00`
-- | --
Add just a keyevent to existing module | `add o/event m/MODULECODE ke/TYPE dt/DATETIME`  E.g. `add o/event m/CS2103 ke/1 dt/2022-05-04 13:00`

</div></b><!--EndFragment-->
</body>
</html>