### PR TITLE
Change message for view switch

### DIFF
--- a/src/main/java/unibook/commons/core/Messages.java
+++ b/src/main/java/unibook/commons/core/Messages.java
@@ -16,6 +16,9 @@ public class Messages {
     public static final String MESSAGE_MODULE_CODE_NOT_EXIST = "Module Code does not exist: %1$s";
 
     //ListCommand
+    public static final String MESSAGE_CHANGED_TO_MODULE_PAGE = "Changed page to Module Page!";
+    public static final String MESSAGE_CHANGED_TO_PERSON_PAGE = "Changed page to Person Page!";
+    public static final String MESSAGE_CHANGED_TO_GROUP_PAGE = "Changed page to Group Page!";
     public static final String MESSAGE_ALREADY_ON_PEOPLE_PAGE = "You are already on the People view!";
     public static final String MESSAGE_ALREADY_ON_MODULE_PAGE = "You are already on the Modules view!";
     public static final String MESSAGE_ALREADY_ON_GROUP_PAGE = "You are already on the Groups view!";

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -302,7 +302,7 @@ public class ListCommand extends Command {
                     return new CommandResult(Messages.MESSAGE_ALREADY_ON_MODULE_PAGE);
                 } else {
                     modelManager.getUi().setModuleListPanel();
-                    return new CommandResult(Messages.MESSAGE_CHANGE_TO_MODULE_PAGE);
+                    return new CommandResult(Messages.MESSAGE_CHANGED_TO_MODULE_PAGE);
                 }
             } else if (this.viewType == ListView.PEOPLE) {
                 //Switch view to people
@@ -310,7 +310,7 @@ public class ListCommand extends Command {
                     return new CommandResult(Messages.MESSAGE_ALREADY_ON_PEOPLE_PAGE);
                 } else {
                     modelManager.getUi().setPersonListPanel();
-                    return new CommandResult(Messages.MESSAGE_CHANGE_TO_PERSON_PAGE);
+                    return new CommandResult(Messages.MESSAGE_CHANGED_TO_PERSON_PAGE);
                 }
             } else {
                 //Switch view to groups
@@ -328,7 +328,7 @@ public class ListCommand extends Command {
                         }
                     }
                     modelManager.getUi().setGroupListPanel(groups);
-                    return new CommandResult(Messages.MESSAGE_CHANGE_TO_GROUP_PAGE);
+                    return new CommandResult(Messages.MESSAGE_CHANGED_TO_GROUP_PAGE);
                 }
             }
         case PEOPLEINGROUP:


### PR DESCRIPTION
Added past tense for messages involving changing of page successfully. @ryanwalterlee you can go ahead and use the present tense one. thanks!