### PR TITLE
Bug fixes for List Command

### DIFF
--- a/src/main/java/unibook/commons/core/Messages.java
+++ b/src/main/java/unibook/commons/core/Messages.java
@@ -32,6 +32,9 @@ public class Messages {
     public static final String MESSAGE_GROUP_NOT_EXIST = "Group does not exist: %1$s";
     public static final String MESSAGE_INVALID_MODULE_CODE = "Invalid Module Code! Module Codes must contain 1-10 "
             + "alphanumeric characters.";
+    public static final String MESSAGE_INVALID_MODULE_NAME = "Invalid Module Name! Module Names must contain 1-50 "
+            + "alphanumeric characters.";
+
 
     //ListCommand
     public static final String MESSAGE_FIELD_EMPTY = "%s field cannot be empty!";

--- a/src/main/java/unibook/commons/core/Messages.java
+++ b/src/main/java/unibook/commons/core/Messages.java
@@ -30,6 +30,8 @@ public class Messages {
             + "Command to change to group page: list o/view v/groups";
     public static final String MESSAGE_MODULE_CODE_NOT_EXIST = "Module Code does not exist: %1$s";
     public static final String MESSAGE_GROUP_NOT_EXIST = "Group does not exist: %1$s";
+    public static final String MESSAGE_INVALID_MODULE_CODE = "Invalid Module Code! Module Codes must contain 1-10 "
+            + "alphanumeric characters.";
 
     //ListCommand
     public static final String MESSAGE_FIELD_EMPTY = "%s field cannot be empty!";
@@ -65,6 +67,7 @@ public class Messages {
     public static final String MESSAGE_DISPLAYED_MODULES_WITH_DATE = "Displayed modules with key event(s) on %s!";
     public static final String MESSAGE_NO_MODULES_WITH_DATE = "No modules have key events on %s!";
     public static final String MESSAGE_NO_MODULES_WITH_NAME = "No modules have names containing %s!";
+    public static final String MESSAGE_NO_GROUP_FIELD_REQUIRED = "You are on group page! No need to specify o/group!";
     public static final String MESSAGE_INVALID_KEY_EVENT = "Invalid Key Event: %s. Acceptable arguments are "
         + "EXAM, ASSIGNMENT_DUE, ASSIGNMENT_RELEASE or QUIZ.";
     public static final String MESSAGE_DISPLAYED_MODULES_WITH_EVENT_AND_DATE =

--- a/src/main/java/unibook/commons/core/Messages.java
+++ b/src/main/java/unibook/commons/core/Messages.java
@@ -32,6 +32,7 @@ public class Messages {
     public static final String MESSAGE_GROUP_NOT_EXIST = "Group does not exist: %1$s";
 
     //ListCommand
+    public static final String MESSAGE_FIELD_EMPTY = "%s field cannot be empty!";
     public static final String MESSAGE_CHANGED_TO_MODULE_PAGE = "Changed page to Module Page!";
     public static final String MESSAGE_CHANGED_TO_PERSON_PAGE = "Changed page to Person Page!";
     public static final String MESSAGE_CHANGED_TO_GROUP_PAGE = "Changed page to Group Page!";
@@ -54,7 +55,6 @@ public class Messages {
     public static final String MESSAGE_GROUP_FIELD_MISSING = "The g/<GROUPNAME> field is missing!";
     public static final String MESSAGE_VIEW_FIELD_MISSING = "The v/<VIEW> field is missing!";
     public static final String MESSAGE_GROUP_NOT_IN_MODULE = "The group %s does not exist in the module!";
-
     public static final String MESSAGE_GROUP_NOT_IN_UNIBOOK = "The group %s does not exist in Unibook!";
     public static final String MESSAGE_DISPLAYED_GROUPS_WITH_NAME = "Displayed group(s) with name %s!";
     public static final String MESSAGE_DISPLAYED_PEOPLE_IN_GROUP = "Displayed people in %s %s!";

--- a/src/main/java/unibook/logic/commands/EditCommand.java
+++ b/src/main/java/unibook/logic/commands/EditCommand.java
@@ -325,7 +325,10 @@ public class EditCommand extends Command {
             // Update groups in person and modules
             for (Person p : lastShownList) {
                 if (p instanceof Student) {
-                    if (p.getModules().contains(mod)) { ((Student) p).editGroupByMod(mod, editGroupDescriptor); }
+                    if (p.getModules().contains(mod)) {
+                        Student ps = (Student) p;
+                        ps.editGroupByMod(mod, editGroupDescriptor);
+                    }
                 }
             }
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -29,6 +29,22 @@ import unibook.model.person.Student;
  */
 public class ListCommand extends Command {
 
+    /**
+     * Enum type that determines which variant/permutation of a command is executed.
+     */
+    public enum ListCommandType {
+        ALL, MODULE, TYPE, MODULEANDTYPE, VIEW, GROUPFROMMODULEVIEW, PEOPLEINGROUP, GROUPFROMGROUPVIEW,
+        GROUPWITHMEETINGDATE, MODULEWITHNAMEMATCH, MODULESWITHKEYEVENT, MODULESWITHEVENTDATE,
+        MODULESWITHDATEANDKEYEVENT, MODULESWITHDATEANDNAME, MODULESWITHNAMEANDKEYEVENT,
+        MODULESWITHDATEANDKEYEVENTANDNAME, SPECIFICGROUPFROMGROUPVIEW
+    }
+
+    /**
+     * Enum type that determines which view to switch to.
+     */
+    public enum ListView {
+        PEOPLE, MODULES, GROUPS
+    }
 
     public static final String COMMAND_WORD = "list";
 
@@ -40,18 +56,12 @@ public class ListCommand extends Command {
 
 
     private ModuleCode moduleCode;
-
     private String type;
-
     private ListCommandType commandType;
     private ListView viewType;
-
     private String group;
-
     private String date;
-
     private String moduleNameFragment;
-
     private String keyEvent;
 
     /**
@@ -62,9 +72,7 @@ public class ListCommand extends Command {
     }
 
     /**
-     * Constructor for a ListCommand to change the current view.
-     *
-     * @param viewType
+     * Constructor for a ListCommand to change the view.
      */
     public ListCommand(ListView viewType, ListCommandType commandType) {
         assert commandType == ListCommandType.VIEW;
@@ -72,9 +80,9 @@ public class ListCommand extends Command {
         this.viewType = viewType;
     }
 
+
     /**
-     * Constructor for a ListCommand with 1 option and 1 field
-     * eg list o/module m/cs2103 list o/type ty/professors list o/group g/groupname
+     * Constructor for a ListCommand with 1 field.
      */
     public ListCommand(String field, ListCommandType commandType) {
         switch (commandType) {
@@ -116,8 +124,7 @@ public class ListCommand extends Command {
     }
 
     /**
-     * Constructor for a ListCommand with 1 option and 2 fields
-     * eg list o/module m/cs2103 ty/professors
+     * Constructor for a ListCommand with 2 fields.
      */
     public ListCommand(String field1, String field2, ListCommandType commandType) {
         switch (commandType) {
@@ -157,28 +164,19 @@ public class ListCommand extends Command {
     }
 
     /**
-     * Constructor for a ListCommand with 3 fields
-     * eg list n/software dt/2022-05-04 ke/exam
+     * Constructor for a ListCommand with 3 fields.
      */
     public ListCommand(String field1, String field2, String field3, ListCommandType commandType) {
-        switch (commandType) {
-        case MODULESWITHDATEANDKEYEVENTANDNAME:
-            this.commandType = ListCommandType.MODULESWITHDATEANDKEYEVENTANDNAME;
-            this.moduleNameFragment = field1;
-            this.date = field2;
-            this.keyEvent = field3;
-            break;
-        default:
-            break;
-        }
+        //Currently only 1 possible type that takes in 3 fields. Add switch case upon expansion
+        this.commandType = commandType;
+        this.moduleNameFragment = field1;
+        this.date = field2;
+        this.keyEvent = field3;
     }
 
 
     /**
-     * Utility method to quickly show everything. Used to reset before narrowing
-     * to specific criteria.
-     *
-     * @param model
+     * Utility method used to show every entry in a given page when the relevant command is executed.
      */
     private void showAll(Model model) {
         ModelManager mm = (ModelManager) model;
@@ -190,16 +188,16 @@ public class ListCommand extends Command {
             ObservableList<Group> allGroups = FXCollections.observableArrayList();
             for (Module m : model.getUniBook().getModuleList()) {
                 ObservableList<Group> moduleGroups = m.getGroups();
-                for (Group mg : moduleGroups) {
-                    allGroups.add(mg);
-                }
+                allGroups.addAll(moduleGroups);
             }
             mm.getUi().setGroupListPanel(allGroups);
         }
-
-
     }
 
+    /**
+     * Utility method to check if the instance module code exists in a given list of modules.
+     * @return true if module code was found, false otherwise
+     */
     private boolean moduleCodeExists(ObservableList<Module> modules) {
         for (Module m : modules) {
             if (m.hasModuleCode(this.moduleCode)) {
@@ -209,6 +207,10 @@ public class ListCommand extends Command {
         return false;
     }
 
+    /**
+     * Utility method to check if the instance key date exists in a given list of modules.
+     * @return true if key date was found, false otherwise
+     */
     private boolean keyDateExists(ObservableList<Module> modules, LocalDate date) {
         for (Module m : modules) {
             ObservableList<LocalDate> dates = m.getKeyEventDates();
@@ -219,489 +221,10 @@ public class ListCommand extends Command {
         return false;
     }
 
-    @Override
-    public CommandResult execute(Model model, Boolean isPersonListShowing,
-                                 Boolean isModuleListShowing, Boolean isGroupListShowing) throws CommandException {
-        requireNonNull(model);
-        ModelManager modelManager = (ModelManager) model;
-
-        switch (this.commandType) {
-        case ALL:
-            //List everything.
-            showAll(model);
-            return new CommandResult(MESSAGE_SUCCESS);
-        case MODULE:
-            if (!moduleCodeExists(model.getUniBook().getModuleList())) {
-                //The given module does not exist in UniBook.
-                throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
-            }
-            if (modelManager.getUi().isPersonListShowing()) {
-                //Module command given in person page. Displays all people with given module
-                Predicate<Person> showSpecificPeoplePredicate = p -> p.hasModule(this.moduleCode);
-                model.updateFilteredPersonList(showSpecificPeoplePredicate);
-                return new
-                    CommandResult(String.format(Messages.MESSAGE_LISTED_PEOPLE_WITH_MODULE, moduleCode.toString()));
-
-            } else if (modelManager.getUi().isModuleListShowing()) {
-                //Module command given in modules page. Displays specified module.
-                Predicate<Module> showSpecificModulePredicate = m -> m.hasModuleCode(this.moduleCode);
-                model.updateFilteredModuleList(showSpecificModulePredicate);
-                return new CommandResult(String.format(Messages.MESSAGE_LISTED_MODULE, moduleCode.toString()));
-            } else {
-                return new CommandResult(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules or People"));
-            }
-
-        case TYPE:
-            if (modelManager.getUi().isPersonListShowing()) {
-                if (type.equals("professors")) {
-                    //Displays all professors.
-                    model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PROFESSORS);
-                    return new CommandResult(Messages.MESSAGE_LISTED_ALL_PROFESSORS);
-                } else if (type.equals("students")) {
-                    //Displays all students.
-                    model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_STUDENTS);
-                    return new CommandResult(Messages.MESSAGE_LISTED_ALL_STUDENTS);
-                } else {
-                    //Invalid type argument.
-                    throw new CommandException(Messages.MESSAGE_WRONG_TYPE);
-                }
-            } else {
-                //Type command given in (wrong) modules view or groups view.
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "People"));
-            }
-        case MODULEANDTYPE:
-            if (modelManager.getUi().isPersonListShowing()) {
-                if (!moduleCodeExists(model.getUniBook().getModuleList())) {
-                    //The given module does not exist in UniBook.
-                    throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
-                }
-                if (type.equals("professors")) {
-                    //Displays all professors in the given module.
-                    Predicate<Person> showSpecificProfessorPredicate = p -> p.hasModule(this.moduleCode)
-                        && (p instanceof Professor);
-                    model.updateFilteredPersonList(showSpecificProfessorPredicate);
-                    return new CommandResult(
-                        String.format(Messages.MESSAGE_LISTED_ALL_TYPE_IN_MODULE,
-                            "professors", moduleCode.toString()));
-                } else if (type.equals("students")) {
-                    //Displays all students in the given module.
-                    Predicate<Person> showSpecificStudentPredicate = p -> p.hasModule(this.moduleCode)
-                        && (p instanceof Student);
-                    model.updateFilteredPersonList(showSpecificStudentPredicate);
-                    return new CommandResult(
-                        String.format(Messages.MESSAGE_LISTED_ALL_TYPE_IN_MODULE,
-                            "students", moduleCode.toString()));
-                } else {
-                    //Invalid type argument.
-                    throw new CommandException(Messages.MESSAGE_WRONG_TYPE);
-                }
-            } else {
-                //Type command given in (wrong) modules or group view.
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "People"));
-            }
-        case VIEW:
-            showAll(model);
-            if (this.viewType == ListView.MODULES) {
-                //Switch view to modules
-                if (isModuleListShowing) {
-                    return new CommandResult(Messages.MESSAGE_ALREADY_ON_MODULE_PAGE);
-                } else {
-                    modelManager.getUi().setModuleListPanel();
-                    return new CommandResult(Messages.MESSAGE_CHANGED_TO_MODULE_PAGE);
-                }
-            } else if (this.viewType == ListView.PEOPLE) {
-                //Switch view to people
-                if (isPersonListShowing) {
-                    return new CommandResult(Messages.MESSAGE_ALREADY_ON_PEOPLE_PAGE);
-                } else {
-                    modelManager.getUi().setPersonListPanel();
-                    return new CommandResult(Messages.MESSAGE_CHANGED_TO_PERSON_PAGE);
-                }
-            } else {
-                //Switch view to groups
-                assert this.viewType == ListView.GROUPS;
-                if (isGroupListShowing) {
-                    return new CommandResult(Messages.MESSAGE_ALREADY_ON_GROUP_PAGE);
-                } else {
-                    ObservableList<Module> modules = ((UniBook) modelManager.getUniBook())
-                        .getModuleList();
-                    ObservableList<Group> groups = FXCollections.observableArrayList();
-                    for (Module m : modules) {
-                        ObservableList<Group> moduleGroups = m.getGroups();
-                        for (Group mg : moduleGroups) {
-                            groups.add(mg);
-                        }
-                    }
-                    modelManager.getUi().setGroupListPanel(groups);
-                    return new CommandResult(Messages.MESSAGE_CHANGED_TO_GROUP_PAGE);
-                }
-            }
-        case PEOPLEINGROUP:
-            if (modelManager.getUi().isPersonListShowing()) {
-
-                if (!model.hasModule(this.moduleCode)) {
-                    throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, this.moduleCode));
-                }
-
-                Module m = model.getModuleByCode(this.moduleCode);
-
-                if (!m.hasGroupName(this.group)) {
-                    throw new CommandException(String.format(Messages.MESSAGE_GROUP_NOT_IN_MODULE,
-                        this.group, this.moduleCode));
-                }
-
-                Group g = m.getGroupByName(this.group);
-                ObservableList<Student> peopleInGroup = g.getMembers();
-
-
-                Predicate<Person> pred = p -> peopleInGroup.contains(p);
-                model.updateFilteredPersonList(pred);
-                return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_PEOPLE_IN_GROUP,
-                    this.moduleCode.toString(), g.getGroupName()));
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "People"));
-            }
-
-        case GROUPFROMMODULEVIEW:
-            if (modelManager.getUi().isModuleListShowing() && modelManager.getFilteredModuleList().size() == 1) {
-                //The case where 1 module is showing, allow to focus into 1 group
-                //Shows all groups that match given name in aforementioned module.
-                ObservableList<Group> groups = modelManager.getFilteredModuleList().get(0).getGroups();
-                for (Group g : groups) {
-                    if (g.getGroupName().toLowerCase().equals(this.group)) {
-                        if (groups.size() == 0) {
-                            throw new CommandException(
-                                String.format(Messages.MESSAGE_GROUP_NOT_IN_MODULE, this.group.toUpperCase()));
-                        }
-                        modelManager.getUi().setGroupListPanel(FXCollections.observableArrayList(g));
-                        return new CommandResult(String.format(Messages.MESSAGE_LISTED_MODULE_GROUP,
-                            g.getGroupName(), g.getModule().getModuleCode().toString()));
-                    }
-                }
-                throw new CommandException(String.format(
-                    Messages.MESSAGE_GROUP_NOT_IN_MODULE, this.group));
-            } else if (modelManager.getUi().isModuleListShowing()) {
-                try {
-                    //The case where the user is in modules list with >1 module showing
-                    //Shows all groups that match given name.
-                    ObservableList<Group> groups = ((UniBook) modelManager.getUniBook())
-                        .getGroupsWithGroupName(this.group);
-                    if (groups.size() == 0) {
-                        throw new CommandException(
-                            String.format(Messages.MESSAGE_GROUP_NOT_IN_UNIBOOK, this.group.toUpperCase()));
-                    }
-                    modelManager.getUi().setGroupListPanel(groups);
-                    return new CommandResult(String.format(Messages.MESSAGE_LISTED_GROUP_WITH_NAME,
-                        groups.get(0).getGroupName()));
-                } catch (GroupNotFoundException g) {
-                    throw new CommandException(Messages.MESSAGE_GROUP_NOT_IN_UNIBOOK);
-                }
-            } else {
-                if (modelManager.getUi().isPersonListShowing()) {
-                    throw new CommandException(String.format(Messages.MESSAGE_MODULE_FIELD_MISSING));
-                } else {
-                    throw new CommandException("You are on group page! No need to specify o/group");
-                }
-            }
-        case GROUPFROMGROUPVIEW:
-            if (modelManager.getUi().isGroupListShowing()) {
-                ObservableList<Group> groups = FXCollections.observableArrayList();
-                for (Module m : model.getUniBook().getModuleList()) {
-                    ObservableList<Group> moduleGroups = m.getGroups();
-                    for (Group mg : moduleGroups) {
-                        if (mg.getGroupName().toLowerCase().equals(this.group)) {
-                            groups.add(mg);
-                        }
-                    }
-                }
-                if (groups.size() == 0) {
-                    throw new CommandException(
-                        String.format(Messages.MESSAGE_GROUP_NOT_IN_UNIBOOK, this.group.toUpperCase()));
-                }
-                ModelManager mm = (ModelManager) model;
-                mm.getUi().setGroupListPanel(groups);
-                return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_GROUPS_WITH_NAME,
-                    this.group.toUpperCase()));
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Groups"));
-            }
-        case GROUPWITHMEETINGDATE:
-            try {
-                LocalDate localDate = ParserUtil.parseDate(this.date);
-                if (modelManager.getUi().isGroupListShowing()) {
-                    ObservableList<Group> groups = FXCollections.observableArrayList();
-
-                    for (Module m : model.getUniBook().getModuleList()) {
-                        ObservableList<Group> moduleGroups = m.getGroups();
-                        for (Group mg : moduleGroups) {
-                            ObservableList<LocalDate> dates = mg.getMeetingDates();
-                            if (dates.contains(localDate)) {
-                                groups.add(mg);
-                            }
-                        }
-                    }
-
-                    if (groups.size() == 0) {
-                        throw new CommandException(
-                            String.format(Messages.MESSAGE_NO_GROUP_WITH_MEETING_DATE, this.date.toString()));
-                    }
-                    ModelManager mm = (ModelManager) model;
-                    mm.getUi().setGroupListPanel(groups);
-                    return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_GROUPS_WITH_MEETING_DATE,
-                        this.date.toString()));
-
-                } else {
-                    throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Groups"));
-                }
-            } catch (ParseException e) {
-                throw new CommandException(e.getMessage());
-            }
-        case MODULEWITHNAMEMATCH:
-            //Module command given in modules page. Displays specified module.
-            if (modelManager.getUi().isModuleListShowing()) {
-                checkIfKeywordExists(modelManager);
-
-                Predicate<Module> showSpecificModulePredicate = m ->
-                    m.getModuleName().toString().toLowerCase().contains(this.moduleNameFragment.toLowerCase());
-                model.updateFilteredModuleList(showSpecificModulePredicate);
-                return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_NAME,
-                    this.moduleNameFragment));
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
-            }
-        case MODULESWITHKEYEVENT:
-            if (modelManager.getUi().isModuleListShowing()) {
-                try {
-                    ModuleKeyEvent.KeyEventType ke = ModuleKeyEvent.KeyEventType.valueOf(this.keyEvent.toUpperCase());
-                    Predicate<Module> showSpecificModulePredicate = m -> {
-                        ObservableList<ModuleKeyEvent> allKeyEvents = m.getKeyEvents();
-                        for (ModuleKeyEvent k : allKeyEvents) {
-                            if (k.getKeyEventType() == ke) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    };
-                    model.updateFilteredModuleList(showSpecificModulePredicate);
-                    return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_KEY_EVENT,
-                        this.keyEvent));
-                } catch (IllegalArgumentException e) {
-                    throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
-                }
-
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
-            }
-        case MODULESWITHEVENTDATE:
-            if (modelManager.getUi().isModuleListShowing()) {
-                try {
-                    LocalDate localDate = ParserUtil.parseDate(this.date);
-
-                    if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
-                        throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, localDate));
-                    }
-
-                    Predicate<Module> showSpecificModulePredicate = m -> m.getKeyEventDates().contains(localDate);
-                    model.updateFilteredModuleList(showSpecificModulePredicate);
-                    return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_DATE,
-                        localDate.toString()));
-
-                } catch (ParseException e) {
-                    throw new CommandException(e.getMessage());
-                }
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
-            }
-        case MODULESWITHDATEANDKEYEVENT:
-            if (modelManager.getUi().isModuleListShowing()) {
-                try {
-                    LocalDate localDate = ParserUtil.parseDate(this.date);
-
-                    if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
-                        throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, localDate));
-                    }
-
-                    try {
-                        ModuleKeyEvent.KeyEventType ke =
-                            ModuleKeyEvent.KeyEventType.valueOf(this.keyEvent.toUpperCase());
-                    } catch (IllegalArgumentException e) {
-                        throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
-                    }
-
-
-                    Predicate<Module> showSpecificModulePredicate = m -> {
-                        ObservableList<ModuleKeyEvent> keyEvents = m.getKeyEvents();
-                        for (ModuleKeyEvent k : keyEvents) {
-                            if (k.getKeyEventType().toString().equals(this.keyEvent.toUpperCase())
-                                && k.getKeyEventDate().equals(localDate)) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    };
-                    model.updateFilteredModuleList(showSpecificModulePredicate);
-
-                    if (model.getFilteredModuleList().isEmpty()) {
-                        model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
-                        throw new CommandException(String.format(Messages.MESSAGE_NO_MODULE_WITH_EVENT_AND_DATE,
-                            this.keyEvent, localDate));
-                    }
-
-                    return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_EVENT_AND_DATE,
-                        this.keyEvent, localDate.toString()));
-
-                } catch (ParseException e) {
-                    throw new CommandException(e.getMessage());
-                }
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
-            }
-        case MODULESWITHDATEANDNAME:
-            if (modelManager.getUi().isModuleListShowing()) {
-                try {
-                    checkIfKeywordExists(modelManager);
-
-                    LocalDate localDate = ParserUtil.parseDate(this.date);
-
-                    if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
-                        throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, localDate));
-                    }
-
-                    Predicate<Module> showSpecificModulePredicate = m -> {
-                        return m.getModuleName().toString().toLowerCase().contains(this.moduleNameFragment
-                            .toLowerCase())
-                            && m.getKeyEvents().stream().map(ke -> ke.getKeyEventDate().equals(localDate))
-                            .collect(Collectors.toList()).contains(true);
-                    };
-                    model.updateFilteredModuleList(showSpecificModulePredicate);
-
-                    if (model.getFilteredModuleList().isEmpty()) {
-                        model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
-                        throw new CommandException(String.format(Messages.MESSAGE_NO_MODULE_WITH_NAME_AND_DATE,
-                            this.moduleNameFragment, localDate));
-                    }
-
-                    return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_NAME_AND_DATE,
-                        this.moduleNameFragment, localDate.toString()));
-
-                } catch (ParseException e) {
-                    throw new CommandException(e.getMessage());
-                }
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
-            }
-        case MODULESWITHNAMEANDKEYEVENT:
-            if (modelManager.getUi().isModuleListShowing()) {
-                checkIfKeywordExists(modelManager);
-
-                try {
-                    ModuleKeyEvent.KeyEventType ke = ModuleKeyEvent.KeyEventType.valueOf(this.keyEvent.toUpperCase());
-                } catch (IllegalArgumentException e) {
-                    throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
-                }
-
-
-                Predicate<Module> showSpecificModulePredicate = m -> {
-                    if (!m.getModuleName().toString().toLowerCase()
-                        .contains(this.moduleNameFragment.toLowerCase())) {
-                        return false;
-                    }
-                    ObservableList<ModuleKeyEvent> keyEvents = m.getKeyEvents();
-                    for (ModuleKeyEvent k : keyEvents) {
-                        if (k.getKeyEventType().toString().equals(this.keyEvent.toUpperCase())) {
-                            return true;
-                        }
-                    }
-                    return false;
-                };
-
-                model.updateFilteredModuleList(showSpecificModulePredicate);
-
-                if (model.getFilteredModuleList().isEmpty()) {
-                    model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
-                    throw new CommandException(String.format(Messages.MESSAGE_NO_MODULE_WITH_EVENT_AND_NAME,
-                        this.keyEvent, this.moduleNameFragment));
-                }
-
-                return new CommandResult(String.format(Messages.MESSAGES_DISPLAYED_MODULES_WITH_EVENT_AND_NAME,
-                    this.keyEvent, this.moduleNameFragment));
-
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
-            }
-        case MODULESWITHDATEANDKEYEVENTANDNAME:
-            if (modelManager.getUi().isModuleListShowing()) {
-                try {
-                    LocalDate localDate = ParserUtil.parseDate(this.date);
-
-                    if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
-                        throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, "Modules"));
-                    }
-
-                    checkIfKeywordExists(modelManager);
-
-                    try {
-                        ModuleKeyEvent.KeyEventType ke = ModuleKeyEvent.KeyEventType
-                            .valueOf(this.keyEvent.toUpperCase());
-                    } catch (IllegalArgumentException e) {
-                        throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
-                    }
-
-                    Predicate<Module> showSpecificModulePredicate = m -> {
-                        if (!m.getModuleName().toString().toLowerCase().contains(moduleNameFragment.toLowerCase())) {
-                            return false;
-                        }
-                        ObservableList<ModuleKeyEvent> keyEvents = m.getKeyEvents();
-                        for (ModuleKeyEvent k : keyEvents) {
-                            if (k.getKeyEventType().toString().equals(this.keyEvent.toUpperCase())
-                                && k.getKeyEventDate().equals(localDate)) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    };
-                    model.updateFilteredModuleList(showSpecificModulePredicate);
-                    if (model.getFilteredModuleList().isEmpty()) {
-                        model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
-                        throw new CommandException(String.format(
-                            Messages.MESSAGE_NO_MODULES_WITH_EVENT_AND_NAME_AND_DATE,
-                            moduleNameFragment, this.keyEvent, localDate));
-                    }
-                    return new CommandResult(String.format(
-                        Messages.MESSAGES_DISPLAYED_MODULES_WITH_EVENT_AND_NAME_AND_DATE,
-                        this.moduleNameFragment, this.keyEvent, localDate.toString()));
-
-                } catch (ParseException e) {
-                    throw new CommandException(e.getMessage());
-                }
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
-            }
-        case SPECIFICGROUPFROMGROUPVIEW:
-            if (modelManager.getUi().isGroupListShowing()) {
-                ObservableList<Group> groups = FXCollections.observableArrayList();
-                if (!model.hasModule(moduleCode)) {
-                    throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
-                }
-                Module module = model.getModuleByCode(this.moduleCode);
-
-                if (!module.hasGroupName(this.group)) {
-                    throw new CommandException(String.format(Messages.MESSAGE_GROUP_NOT_IN_MODULE, this.group));
-                }
-
-                groups.add(module.getGroupByName(this.group));
-                ModelManager mm = (ModelManager) model;
-                mm.getUi().setGroupListPanel(groups);
-                return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_GROUPS_WITH_NAME,
-                        this.group.toUpperCase()));
-            } else {
-                throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Groups"));
-            }
-        default:
-            return new CommandResult("");
-        }
-    }
-
+    /**
+     * Checks if a module name has the instance keyword contained within it in a given model.
+     * If it does not exist, a CommandException is thrown.
+     */
     private void checkIfKeywordExists(ModelManager modelManager) throws CommandException {
         ObservableList<Module> allModules = modelManager.getUniBook().getModuleList();
         boolean found = false;
@@ -714,18 +237,612 @@ public class ListCommand extends Command {
 
         if (!found) {
             throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_NAME,
-                moduleNameFragment));
+                    moduleNameFragment));
         }
     }
 
-    public enum ListCommandType {
-        ALL, MODULE, TYPE, MODULEANDTYPE, VIEW, GROUPFROMMODULEVIEW, PEOPLEINGROUP, GROUPFROMGROUPVIEW,
-        GROUPWITHMEETINGDATE, MODULEWITHNAMEMATCH, MODULESWITHKEYEVENT, MODULESWITHEVENTDATE,
-        MODULESWITHDATEANDKEYEVENT, MODULESWITHDATEANDNAME, MODULESWITHNAMEANDKEYEVENT,
-        MODULESWITHDATEANDKEYEVENTANDNAME, SPECIFICGROUPFROMGROUPVIEW
+    @Override
+    public CommandResult execute(Model model, Boolean isPersonListShowing,
+                                 Boolean isModuleListShowing, Boolean isGroupListShowing) throws CommandException {
+        requireNonNull(model);
+        switch (this.commandType) {
+        case ALL:
+            return allCommand(model);
+        case MODULE:
+            return moduleCommand(model, isPersonListShowing, isModuleListShowing, isGroupListShowing);
+        case TYPE:
+            return typeCommand(model, isPersonListShowing);
+        case MODULEANDTYPE:
+            return moduleAndTypeCommand(model, isPersonListShowing);
+        case VIEW:
+            return viewCommand(model, isPersonListShowing, isModuleListShowing, isGroupListShowing);
+        case PEOPLEINGROUP:
+            return peopleInGroupCommand(model, isPersonListShowing);
+        case GROUPFROMMODULEVIEW:
+            return groupFromModulesCommand(model, isPersonListShowing, isGroupListShowing);
+        case GROUPFROMGROUPVIEW:
+            return groupFromGroupsCommand(model, isGroupListShowing);
+        case GROUPWITHMEETINGDATE:
+            return groupMeetingDateCommand(model, isGroupListShowing);
+        case MODULEWITHNAMEMATCH:
+            return moduleWithNameCommand(model, isModuleListShowing);
+        case MODULESWITHKEYEVENT:
+            return moduleWithKeyEventCommand(model, isModuleListShowing);
+        case MODULESWITHEVENTDATE:
+            return moduleWithDateCommand(model, isModuleListShowing);
+        case MODULESWITHDATEANDKEYEVENT:
+            return moduleWithDateAndEventCommand(model, isModuleListShowing);
+        case MODULESWITHDATEANDNAME:
+            return moduleWithDateAndNameCommand(model, isModuleListShowing);
+        case MODULESWITHNAMEANDKEYEVENT:
+            return moduleWithNameAndEventCommand(model, isModuleListShowing);
+        case MODULESWITHDATEANDKEYEVENTANDNAME:
+            return moduleWithNameAndEventAndDateCommand(model, isModuleListShowing);
+        case SPECIFICGROUPFROMGROUPVIEW:
+            return specificGroupCommand(model, isGroupListShowing);
+        default:
+            return new CommandResult("");
+        }
     }
 
-    public enum ListView {
-        PEOPLE, MODULES, GROUPS
+    //Utiity method for equals method
+    private static <T> boolean equalsIfNotNull(T attr1, T attr2) {
+        return attr1 == null || attr2 == null || attr1.equals(attr2);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ListCommand)) {
+            return false;
+        }
+
+        ListCommand lc = (ListCommand) o;
+
+        return equalsIfNotNull(lc.moduleCode, moduleCode)
+                && equalsIfNotNull(lc.type, type)
+                && equalsIfNotNull(lc.commandType.toString(), commandType.toString())
+                && equalsIfNotNull(lc.viewType, viewType)
+                && equalsIfNotNull(lc.group, group)
+                && equalsIfNotNull(lc.date, date)
+                && equalsIfNotNull(lc.moduleNameFragment, moduleNameFragment)
+                && equalsIfNotNull(lc.keyEvent, keyEvent);
+    }
+
+
+    @Override
+    public String toString() {
+        return this.type;
+    }
+
+    private CommandResult allCommand(Model model) {
+        //List everything. Example: `list`
+        showAll(model);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    private CommandResult moduleCommand(Model model, Boolean isPersonListShowing, Boolean isModuleListShowing,
+                                        Boolean isGroupListShowing) throws CommandException {
+        //Module command given in People or Module page.
+        if (!moduleCodeExists(model.getUniBook().getModuleList())) {
+            //The module code given does not exist in the UniBook.
+            throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
+        }
+
+        if (isGroupListShowing) {
+            //Module command given in groups page (Invalid)
+            return new CommandResult(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules or People"));
+        }
+
+        if (isPersonListShowing) {
+            //Module command given in person page. Displays all people with the given module.
+            Predicate<Person> showSpecificPeoplePredicate = p -> p.hasModule(this.moduleCode);
+            model.updateFilteredPersonList(showSpecificPeoplePredicate);
+            return new
+                    CommandResult(String.format(Messages.MESSAGE_LISTED_PEOPLE_WITH_MODULE, moduleCode.toString()));
+        }
+
+        if (isModuleListShowing) {
+            //Module command given in modules page. Displays the specified module.
+            Predicate<Module> showSpecificModulePredicate = m -> m.hasModuleCode(this.moduleCode);
+            model.updateFilteredModuleList(showSpecificModulePredicate);
+            return new CommandResult(String.format(Messages.MESSAGE_LISTED_MODULE, moduleCode.toString()));
+        }
+
+        return new CommandResult("");
+    }
+
+    private CommandResult typeCommand(Model model, Boolean isPersonListShowing) throws CommandException {
+        if (!isPersonListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "People"));
+        }
+
+        //Type command given in People page.
+        if (type.equals("professors")) {
+            //Displays all professors.
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PROFESSORS);
+            return new CommandResult(Messages.MESSAGE_LISTED_ALL_PROFESSORS);
+        } else if (type.equals("students")) {
+            //Displays all students.
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_STUDENTS);
+            return new CommandResult(Messages.MESSAGE_LISTED_ALL_STUDENTS);
+        } else {
+            //Invalid type argument.
+            throw new CommandException(Messages.MESSAGE_WRONG_TYPE);
+        }
+    }
+
+    private CommandResult moduleAndTypeCommand(Model model, Boolean isPersonListShowing) throws CommandException {
+        if (!isPersonListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "People"));
+        }
+
+        if (!moduleCodeExists(model.getUniBook().getModuleList())) {
+            //The given module does not exist in UniBook.
+            throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
+        }
+
+        if (type.equals("professors")) {
+            //Displays all professors in the given module.
+            Predicate<Person> showSpecificProfessorPredicate = p -> p.hasModule(this.moduleCode)
+                    && (p instanceof Professor);
+            model.updateFilteredPersonList(showSpecificProfessorPredicate);
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_LISTED_ALL_TYPE_IN_MODULE,
+                            "professors", moduleCode.toString()));
+        } else if (type.equals("students")) {
+            //Displays all students in the given module.
+            Predicate<Person> showSpecificStudentPredicate = p -> p.hasModule(this.moduleCode)
+                    && (p instanceof Student);
+            model.updateFilteredPersonList(showSpecificStudentPredicate);
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_LISTED_ALL_TYPE_IN_MODULE,
+                            "students", moduleCode.toString()));
+        } else {
+            //Invalid type argument.
+            throw new CommandException(Messages.MESSAGE_WRONG_TYPE);
+        }
+    }
+
+    private CommandResult viewCommand(Model model, Boolean isPersonListShowing, Boolean isModuleListShowing,
+                                      Boolean isGroupListShowing) {
+        ModelManager modelManager = (ModelManager) model;
+        showAll(model);
+        if (this.viewType == ListView.MODULES) {
+            //Switch view to modules
+            if (isModuleListShowing) {
+                return new CommandResult(Messages.MESSAGE_ALREADY_ON_MODULE_PAGE);
+            } else {
+                modelManager.getUi().setModuleListPanel();
+                return new CommandResult(Messages.MESSAGE_CHANGED_TO_MODULE_PAGE);
+            }
+        } else if (this.viewType == ListView.PEOPLE) {
+            //Switch view to people
+            if (isPersonListShowing) {
+                return new CommandResult(Messages.MESSAGE_ALREADY_ON_PEOPLE_PAGE);
+            } else {
+                modelManager.getUi().setPersonListPanel();
+                return new CommandResult(Messages.MESSAGE_CHANGED_TO_PERSON_PAGE);
+            }
+        } else {
+            //Switch view to groups
+            assert this.viewType == ListView.GROUPS;
+            if (isGroupListShowing) {
+                return new CommandResult(Messages.MESSAGE_ALREADY_ON_GROUP_PAGE);
+            } else {
+                ObservableList<Module> modules = modelManager.getUniBook()
+                        .getModuleList();
+                ObservableList<Group> groups = FXCollections.observableArrayList();
+                for (Module m : modules) {
+                    ObservableList<Group> moduleGroups = m.getGroups();
+                    groups.addAll(moduleGroups);
+                }
+                modelManager.getUi().setGroupListPanel(groups);
+                return new CommandResult(Messages.MESSAGE_CHANGED_TO_GROUP_PAGE);
+            }
+        }
+    }
+
+    private CommandResult peopleInGroupCommand(Model model, Boolean isPersonListShowing) throws CommandException {
+        if (!isPersonListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "People"));
+        }
+
+        if (!model.hasModule(this.moduleCode)) {
+            throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, this.moduleCode));
+        }
+
+        Module m = model.getModuleByCode(this.moduleCode);
+
+        if (!m.hasGroupName(this.group)) {
+            throw new CommandException(String.format(Messages.MESSAGE_GROUP_NOT_IN_MODULE, this.group));
+        }
+
+        Group g = m.getGroupByName(this.group);
+        ObservableList<Student> peopleInGroup = g.getMembers();
+        Predicate<Person> pred = p -> peopleInGroup.contains(p);
+        model.updateFilteredPersonList(pred);
+        return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_PEOPLE_IN_GROUP,
+                this.moduleCode.toString(), g.getGroupName()));
+
+    }
+
+    private CommandResult groupFromModulesCommand(Model model, Boolean isPersonListShowing,
+                                                  Boolean isGroupListShowing) throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (isPersonListShowing) {
+            throw new CommandException(Messages.MESSAGE_MODULE_FIELD_MISSING);
+        }
+
+        if (isGroupListShowing) {
+            throw new CommandException("You are on group page! No need to specify o/group");
+        }
+
+        if (modelManager.getFilteredModuleList().size() == 1) {
+            //The case where 1 module is showing, allow to focus into 1 group
+            //Shows all groups that match given name in aforementioned module.
+            ObservableList<Group> groups = modelManager.getFilteredModuleList().get(0).getGroups();
+            for (Group g : groups) {
+                if (g.getGroupName().toLowerCase().equals(this.group)) {
+                    if (groups.size() == 0) {
+                        throw new CommandException(
+                                String.format(Messages.MESSAGE_GROUP_NOT_IN_MODULE, this.group.toUpperCase()));
+                    }
+                    modelManager.getUi().setGroupListPanel(FXCollections.observableArrayList(g));
+                    return new CommandResult(String.format(Messages.MESSAGE_LISTED_MODULE_GROUP,
+                            g.getGroupName(), g.getModule().getModuleCode().toString()));
+                }
+            }
+            throw new CommandException(String.format(Messages.MESSAGE_GROUP_NOT_IN_MODULE, this.group));
+        } else {
+            try {
+                //The case where the user is in modules list with >1 module showing
+                //Shows all groups that match given name.
+                ObservableList<Group> groups = ((UniBook) modelManager.getUniBook())
+                        .getGroupsWithGroupName(this.group);
+                if (groups.size() == 0) {
+                    throw new CommandException(
+                            String.format(Messages.MESSAGE_GROUP_NOT_IN_UNIBOOK, this.group.toUpperCase()));
+                }
+                modelManager.getUi().setGroupListPanel(groups);
+                return new CommandResult(String.format(Messages.MESSAGE_LISTED_GROUP_WITH_NAME,
+                        groups.get(0).getGroupName()));
+            } catch (GroupNotFoundException g) {
+                throw new CommandException(Messages.MESSAGE_GROUP_NOT_IN_UNIBOOK);
+            }
+        }
+    }
+
+    private CommandResult groupFromGroupsCommand(Model model,
+                                                 Boolean isGroupListShowing) throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (!isGroupListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Groups"));
+        }
+
+        ObservableList<Group> groups = FXCollections.observableArrayList();
+        for (Module m : model.getUniBook().getModuleList()) {
+            ObservableList<Group> moduleGroups = m.getGroups();
+            for (Group mg : moduleGroups) {
+                if (mg.getGroupName().toLowerCase().equals(this.group)) {
+                    groups.add(mg);
+                }
+            }
+        }
+        if (groups.size() == 0) {
+            throw new CommandException(
+                    String.format(Messages.MESSAGE_GROUP_NOT_IN_UNIBOOK, this.group.toUpperCase()));
+        }
+
+        modelManager.getUi().setGroupListPanel(groups);
+        return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_GROUPS_WITH_NAME,
+                this.group.toUpperCase()));
+    }
+
+    private CommandResult groupMeetingDateCommand(Model model,
+                                                  Boolean isGroupListShowing) throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (!isGroupListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Groups"));
+
+        }
+
+        try {
+            LocalDate localDate = ParserUtil.parseDate(this.date);
+            ObservableList<Group> groups = FXCollections.observableArrayList();
+            for (Module m : model.getUniBook().getModuleList()) {
+                ObservableList<Group> moduleGroups = m.getGroups();
+                for (Group mg : moduleGroups) {
+                    ObservableList<LocalDate> dates = mg.getMeetingDates();
+                    if (dates.contains(localDate)) {
+                        groups.add(mg);
+                    }
+                }
+            }
+
+            if (groups.size() == 0) {
+                throw new CommandException(
+                        String.format(Messages.MESSAGE_NO_GROUP_WITH_MEETING_DATE, this.date));
+            }
+
+            modelManager.getUi().setGroupListPanel(groups);
+            return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_GROUPS_WITH_MEETING_DATE, this.date));
+
+        } catch (ParseException e) {
+            throw new CommandException(e.getMessage());
+        }
+    }
+
+    private CommandResult moduleWithNameCommand(Model model, Boolean isModuleListShowing) throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (!isModuleListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
+        }
+
+        //Module command given in modules page. Displays specified module.
+        checkIfKeywordExists(modelManager);
+        Predicate<Module> showSpecificModulePredicate = m ->
+                m.getModuleName().toString().toLowerCase().contains(this.moduleNameFragment.toLowerCase());
+        model.updateFilteredModuleList(showSpecificModulePredicate);
+        return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_NAME,
+                this.moduleNameFragment));
+    }
+
+    private CommandResult moduleWithKeyEventCommand(Model model, Boolean isModuleListShowing) throws CommandException {
+        if (!isModuleListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
+        }
+
+        try {
+            ModuleKeyEvent.KeyEventType ke = ModuleKeyEvent.KeyEventType.valueOf(this.keyEvent.toUpperCase());
+            Predicate<Module> showSpecificModulePredicate = m -> {
+                ObservableList<ModuleKeyEvent> allKeyEvents = m.getKeyEvents();
+                for (ModuleKeyEvent k : allKeyEvents) {
+                    if (k.getKeyEventType() == ke) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            model.updateFilteredModuleList(showSpecificModulePredicate);
+            return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_KEY_EVENT,
+                    this.keyEvent));
+        } catch (IllegalArgumentException e) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
+        }
+
+    }
+
+    private CommandResult moduleWithDateCommand(Model model, Boolean isModuleListShowing) throws CommandException {
+        if (!isModuleListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
+        }
+
+        try {
+            LocalDate localDate = ParserUtil.parseDate(this.date);
+
+            if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
+                throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, localDate));
+            }
+
+            Predicate<Module> showSpecificModulePredicate = m -> m.getKeyEventDates().contains(localDate);
+            model.updateFilteredModuleList(showSpecificModulePredicate);
+            return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_DATE,
+                    localDate.toString()));
+
+        } catch (ParseException e) {
+            throw new CommandException(e.getMessage());
+        }
+    }
+
+    private CommandResult moduleWithDateAndEventCommand(Model model, Boolean isModuleListShowing)
+            throws CommandException {
+        if (!isModuleListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
+        }
+
+        try {
+            LocalDate localDate = ParserUtil.parseDate(this.date);
+
+            if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
+                throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, localDate));
+            }
+
+            try {
+                ModuleKeyEvent.KeyEventType ke =
+                        ModuleKeyEvent.KeyEventType.valueOf(this.keyEvent.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
+            }
+
+            Predicate<Module> showSpecificModulePredicate = m -> {
+                ObservableList<ModuleKeyEvent> keyEvents = m.getKeyEvents();
+                for (ModuleKeyEvent k : keyEvents) {
+                    if (k.getKeyEventType().toString().equals(this.keyEvent.toUpperCase())
+                            && k.getKeyEventDate().equals(localDate)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+            model.updateFilteredModuleList(showSpecificModulePredicate);
+
+            if (model.getFilteredModuleList().isEmpty()) {
+                model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
+                throw new CommandException(String.format(Messages.MESSAGE_NO_MODULE_WITH_EVENT_AND_DATE,
+                        this.keyEvent, localDate));
+            }
+
+            return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_EVENT_AND_DATE,
+                    this.keyEvent, localDate.toString()));
+
+        } catch (ParseException e) {
+            throw new CommandException(e.getMessage());
+        }
+
+    }
+
+    private CommandResult moduleWithDateAndNameCommand(Model model, Boolean isModuleListShowing)
+            throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (!isModuleListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
+        }
+
+        try {
+            checkIfKeywordExists(modelManager);
+
+            LocalDate localDate = ParserUtil.parseDate(this.date);
+
+            if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
+                throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, localDate));
+            }
+
+            Predicate<Module> showSpecificModulePredicate = m -> {
+                return m.getModuleName().toString().toLowerCase().contains(this.moduleNameFragment
+                        .toLowerCase())
+                        && m.getKeyEvents().stream().map(ke -> ke.getKeyEventDate().equals(localDate))
+                        .collect(Collectors.toList()).contains(true);
+            };
+            model.updateFilteredModuleList(showSpecificModulePredicate);
+
+            if (model.getFilteredModuleList().isEmpty()) {
+                model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
+                throw new CommandException(String.format(Messages.MESSAGE_NO_MODULE_WITH_NAME_AND_DATE,
+                        this.moduleNameFragment, localDate));
+            }
+
+            return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_MODULES_WITH_NAME_AND_DATE,
+                    this.moduleNameFragment, localDate.toString()));
+
+        } catch (ParseException e) {
+            throw new CommandException(e.getMessage());
+        }
+    }
+
+    private CommandResult moduleWithNameAndEventCommand(Model model, Boolean isModuleListShowing)
+            throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (!isModuleListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
+        }
+
+        checkIfKeywordExists(modelManager);
+
+        try {
+            ModuleKeyEvent.KeyEventType.valueOf(this.keyEvent.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
+        }
+
+
+        Predicate<Module> showSpecificModulePredicate = m -> {
+            if (!m.getModuleName().toString().toLowerCase()
+                    .contains(this.moduleNameFragment.toLowerCase())) {
+                return false;
+            }
+            ObservableList<ModuleKeyEvent> keyEvents = m.getKeyEvents();
+            for (ModuleKeyEvent k : keyEvents) {
+                if (k.getKeyEventType().toString().equals(this.keyEvent.toUpperCase())) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        model.updateFilteredModuleList(showSpecificModulePredicate);
+
+        if (model.getFilteredModuleList().isEmpty()) {
+            model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
+            throw new CommandException(String.format(Messages.MESSAGE_NO_MODULE_WITH_EVENT_AND_NAME,
+                    this.keyEvent, this.moduleNameFragment));
+        }
+
+        return new CommandResult(String.format(Messages.MESSAGES_DISPLAYED_MODULES_WITH_EVENT_AND_NAME,
+                this.keyEvent, this.moduleNameFragment));
+
+    }
+
+    private CommandResult moduleWithNameAndEventAndDateCommand(Model model, Boolean isModuleListShowing)
+            throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (!isModuleListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Modules"));
+        }
+
+        try {
+            LocalDate localDate = ParserUtil.parseDate(this.date);
+
+            if (!keyDateExists(model.getUniBook().getModuleList(), localDate)) {
+                throw new CommandException(String.format(Messages.MESSAGE_NO_MODULES_WITH_DATE, "Modules"));
+            }
+
+            checkIfKeywordExists(modelManager);
+
+            try {
+                ModuleKeyEvent.KeyEventType ke = ModuleKeyEvent.KeyEventType
+                        .valueOf(this.keyEvent.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new CommandException(String.format(Messages.MESSAGE_INVALID_KEY_EVENT, this.keyEvent));
+            }
+
+            Predicate<Module> showSpecificModulePredicate = m -> {
+                if (!m.getModuleName().toString().toLowerCase().contains(moduleNameFragment.toLowerCase())) {
+                    return false;
+                }
+                ObservableList<ModuleKeyEvent> keyEvents = m.getKeyEvents();
+                for (ModuleKeyEvent k : keyEvents) {
+                    if (k.getKeyEventType().toString().equals(this.keyEvent.toUpperCase())
+                            && k.getKeyEventDate().equals(localDate)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            model.updateFilteredModuleList(showSpecificModulePredicate);
+            if (model.getFilteredModuleList().isEmpty()) {
+                model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
+                throw new CommandException(String.format(
+                        Messages.MESSAGE_NO_MODULES_WITH_EVENT_AND_NAME_AND_DATE,
+                        moduleNameFragment, this.keyEvent, localDate));
+            }
+            return new CommandResult(String.format(
+                    Messages.MESSAGES_DISPLAYED_MODULES_WITH_EVENT_AND_NAME_AND_DATE,
+                    this.moduleNameFragment, this.keyEvent, localDate.toString()));
+
+        } catch (ParseException e) {
+            throw new CommandException(e.getMessage());
+        }
+    }
+
+    private CommandResult specificGroupCommand(Model model,
+                                               Boolean isGroupListShowing) throws CommandException {
+        ModelManager modelManager = (ModelManager) model;
+
+        if (!isGroupListShowing) {
+            throw new CommandException(String.format(Messages.MESSAGE_WRONG_VIEW, "Groups"));
+        }
+
+        ObservableList<Group> groups = FXCollections.observableArrayList();
+        if (!model.hasModule(moduleCode)) {
+            throw new CommandException(String.format(Messages.MESSAGE_MODULE_CODE_NOT_EXIST, moduleCode));
+        }
+        Module module = model.getModuleByCode(this.moduleCode);
+
+        if (!module.hasGroupName(this.group)) {
+            throw new CommandException(String.format(Messages.MESSAGE_GROUP_NOT_IN_MODULE, this.group));
+        }
+
+        groups.add(module.getGroupByName(this.group));
+        modelManager.getUi().setGroupListPanel(groups);
+        return new CommandResult(String.format(Messages.MESSAGE_DISPLAYED_GROUPS_WITH_NAME,
+                this.group.toUpperCase()));
     }
 }

--- a/src/main/java/unibook/logic/commands/ListCommand.java
+++ b/src/main/java/unibook/logic/commands/ListCommand.java
@@ -475,7 +475,7 @@ public class ListCommand extends Command {
         }
 
         if (isGroupListShowing) {
-            throw new CommandException("You are on group page! No need to specify o/group");
+            throw new CommandException(Messages.MESSAGE_NO_GROUP_FIELD_REQUIRED);
         }
 
         if (modelManager.getFilteredModuleList().size() == 1) {

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -6,6 +6,7 @@ import unibook.commons.core.Messages;
 import unibook.logic.commands.ListCommand;
 import unibook.logic.parser.exceptions.ParseException;
 import unibook.model.module.ModuleCode;
+import unibook.model.module.ModuleName;
 
 
 /**
@@ -82,6 +83,10 @@ public class ListCommandParser implements Parser<ListCommand> {
             throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
         }
 
+        if (!ModuleName.isValidModuleName(name)) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_MODULE_NAME));
+        }
+
         return new ListCommand(name, dateString, keyEvent.toUpperCase(),
                 ListCommand.ListCommandType.MODULESWITHDATEANDKEYEVENTANDNAME);
     }
@@ -117,6 +122,10 @@ public class ListCommandParser implements Parser<ListCommand> {
             throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
         }
 
+        if (!ModuleName.isValidModuleName(name)) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_MODULE_NAME));
+        }
+
         return new ListCommand(dateString, name,
                 ListCommand.ListCommandType.MODULESWITHDATEANDNAME);
     }
@@ -134,6 +143,9 @@ public class ListCommandParser implements Parser<ListCommand> {
             throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
         }
 
+        if (!ModuleName.isValidModuleName(name)) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_MODULE_NAME));
+        }
 
         return new ListCommand(name, keyEvent,
                 ListCommand.ListCommandType.MODULESWITHNAMEANDKEYEVENT);
@@ -229,6 +241,10 @@ public class ListCommandParser implements Parser<ListCommand> {
 
         if (name.strip().isEmpty()) {
             throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+        }
+
+        if (!ModuleName.isValidModuleName(name)) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_MODULE_NAME));
         }
 
         return new ListCommand(name, ListCommand.ListCommandType.MODULEWITHNAMEMATCH);

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 import unibook.commons.core.Messages;
 import unibook.logic.commands.ListCommand;
 import unibook.logic.parser.exceptions.ParseException;
+import unibook.model.module.ModuleCode;
 
 
 /**
@@ -45,6 +46,19 @@ public class ListCommandParser implements Parser<ListCommand> {
                     String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
                     String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
                     String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
+
+                    if (dateString.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+                    }
+
+                    if (keyEvent.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+                    }
+
+                    if (name.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+                    }
+
                     return new ListCommand(name, dateString, keyEvent.toUpperCase(),
                         ListCommand.ListCommandType.MODULESWITHDATEANDKEYEVENTANDNAME);
                 }
@@ -53,6 +67,16 @@ public class ListCommandParser implements Parser<ListCommand> {
                     //e.g. list dt/2022-05-04 ke/exam
                     String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
                     String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
+
+                    if (dateString.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+                    }
+
+                    if (keyEvent.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+                    }
+
+
                     return new ListCommand(dateString, keyEvent.toUpperCase(),
                         ListCommand.ListCommandType.MODULESWITHDATEANDKEYEVENT);
                 }
@@ -60,6 +84,15 @@ public class ListCommandParser implements Parser<ListCommand> {
                     //On module page, checking for modules with specific name match and date time
                     String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
                     String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
+
+                    if (dateString.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+                    }
+
+                    if (name.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+                    }
+
                     return new ListCommand(dateString, name,
                         ListCommand.ListCommandType.MODULESWITHDATEANDNAME);
                 }
@@ -67,6 +100,16 @@ public class ListCommandParser implements Parser<ListCommand> {
                     //On module page, checking for modules with specific name match and key event
                     String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
                     String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
+
+                    if (name.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+                    }
+
+                    if (keyEvent.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+                    }
+
+
                     return new ListCommand(name, keyEvent,
                         ListCommand.ListCommandType.MODULESWITHNAMEANDKEYEVENT);
 
@@ -75,19 +118,40 @@ public class ListCommandParser implements Parser<ListCommand> {
                     //Listing types of people on people page
                     //e.g. list type/professors
                     String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
+
+                    if (type.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Type"));
+                    }
+
+
                     if (!(type.equals("professors") || type.equals("students"))) {
                         //invalid type argument
                         throw new ParseException(
                             String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, Messages.MESSAGE_WRONG_TYPE));
                     }
+
                     return new ListCommand(type, ListCommand.ListCommandType.TYPE);
                 } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_GROUP)) {
                     //Group prefix present without option field (Listing groups from group page)
                     String group = argMultimap.getValue(CliSyntax.PREFIX_GROUP).get().toLowerCase();
 
+                    if (group.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Group"));
+                    }
+
                     if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
                         //list g/W16-1 m/module
                         String module = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toLowerCase();
+
+                        if (!ModuleCode.isValidModuleCode(module)) {
+                            throw new ParseException("Module Codes should only contain alphanumeric characters.");
+                        }
+
+                        if (module.strip().isEmpty()) {
+                            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+                        }
+
+
                         return new ListCommand(group, module, ListCommand.ListCommandType.SPECIFICGROUPFROMGROUPVIEW);
                     }
 
@@ -98,24 +162,53 @@ public class ListCommandParser implements Parser<ListCommand> {
                     //e.g. list mt/<YYYY-MM-DD>
 
                     String dateString = argMultimap.getValue(CliSyntax.PREFIX_MEETINGTIME).get();
+
+                    if (dateString.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Meeting"));
+                    }
+
                     return new ListCommand(dateString, ListCommand.ListCommandType.GROUPWITHMEETINGDATE);
                 } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_DATETIME)) {
                     String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
+
+                    if (dateString.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+                    }
+
                     return new ListCommand(dateString, ListCommand.ListCommandType.MODULESWITHEVENTDATE);
                 } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_KEYEVENT)) {
                     //Listing modules that contain the given key event
                     //e.g. list ke/exam, list ke/quiz
                     String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
+
+                    if (keyEvent.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+                    }
+
                     return new ListCommand(keyEvent, ListCommand.ListCommandType.MODULESWITHKEYEVENT);
                 } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME)) {
                     //Listing modules that contain the given name on module page
                     // e.g. list n/software, list n/operating systems
                     // Name only
                     String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
+
+                    if (name.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+                    }
+
                     return new ListCommand(name, ListCommand.ListCommandType.MODULEWITHNAMEMATCH);
                 } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
                     //listing module code in module view
                     String moduleCode = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
+
+                    if (moduleCode.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+                    }
+
+                    if (!ModuleCode.isValidModuleCode(moduleCode)) {
+                        throw new ParseException("Module Codes should only contain alphanumeric characters.");
+                    }
+
                     return new ListCommand(moduleCode, ListCommand.ListCommandType.MODULE);
                 } else {
                     throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
@@ -128,6 +221,11 @@ public class ListCommandParser implements Parser<ListCommand> {
             case "view":
                 if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_VIEW)) {
                     String view = argMultimap.getValue(CliSyntax.PREFIX_VIEW).get().toLowerCase();
+
+                    if (view.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "View"));
+                    }
+
                     if (view.equals("modules")) {
                         //Change to module view
                         return new ListCommand(ListCommand.ListView.MODULES, ListCommand.ListCommandType.VIEW);
@@ -155,9 +253,23 @@ public class ListCommandParser implements Parser<ListCommand> {
                         Messages.MESSAGE_MODULE_FIELD_MISSING));
                 }
                 String moduleCode = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
+
+                if (moduleCode.strip().isEmpty()) {
+                    throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+                }
+
+                if (!ModuleCode.isValidModuleCode(moduleCode)) {
+                    throw new ParseException("Module Codes should only contain alphanumeric characters.");
+                }
+
                 if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
                     //list module with specific type, e.g. list o/module m/cs2103 ty/professors
                     String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
+
+                    if (type.strip().isEmpty()) {
+                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Type"));
+                    }
+
                     if (!(type.equals("professors") || type.equals("students"))) {
                         throw new ParseException(
                             String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
@@ -166,6 +278,11 @@ public class ListCommandParser implements Parser<ListCommand> {
                     return new ListCommand(moduleCode, type, ListCommand.ListCommandType.MODULEANDTYPE);
                 } else {
                     //list module with no specific type e.g. list o/module m/cs2103 (in people page)
+
+                    if (!ModuleCode.isValidModuleCode(moduleCode)) {
+                        throw new ParseException("Module Codes should only contain alphanumeric characters.");
+                    }
+
                     return new ListCommand(moduleCode, ListCommand.ListCommandType.MODULE);
                 }
             case "group":
@@ -177,6 +294,10 @@ public class ListCommandParser implements Parser<ListCommand> {
                 }
                 String group = argMultimap.getValue(CliSyntax.PREFIX_GROUP).get().toLowerCase();
 
+                if (group.strip().isEmpty()) {
+                    throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Group"));
+                }
+
                 if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
                     //Module page listing group
                     return new ListCommand(group, ListCommand.ListCommandType.GROUPFROMMODULEVIEW);
@@ -184,6 +305,11 @@ public class ListCommandParser implements Parser<ListCommand> {
                 //People page listing group in a specific module
                 //e.g. list o/group m/cs2103 g/w16-1
                 String module = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
+
+                if (module.strip().isEmpty()) {
+                    throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+                }
+
                 return new ListCommand(group, module, ListCommand.ListCommandType.PEOPLEINGROUP);
 
             default:

--- a/src/main/java/unibook/logic/parser/ListCommandParser.java
+++ b/src/main/java/unibook/logic/parser/ListCommandParser.java
@@ -24,303 +24,382 @@ public class ListCommandParser implements Parser<ListCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListCommand parse(String args) throws ParseException {
-        try {
-            ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_OPTION, CliSyntax.PREFIX_TYPE,
-                    CliSyntax.PREFIX_MODULE, CliSyntax.PREFIX_VIEW, CliSyntax.PREFIX_GROUP,
-                    CliSyntax.PREFIX_MEETINGTIME, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_KEYEVENT,
-                    CliSyntax.PREFIX_DATETIME);
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_OPTION, CliSyntax.PREFIX_TYPE,
+                CliSyntax.PREFIX_MODULE, CliSyntax.PREFIX_VIEW, CliSyntax.PREFIX_GROUP,
+                CliSyntax.PREFIX_MEETINGTIME, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_KEYEVENT,
+                CliSyntax.PREFIX_DATETIME);
 
-            //List all (empty list command)
-            if (args.strip().equals("")) {
-                return new ListCommand();
-            }
-
-            if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_OPTION)) {
-                //Commands that have no option field
-                //Very specific command chain with 2-3 arguments
-                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_DATETIME, CliSyntax.PREFIX_KEYEVENT,
-                    CliSyntax.PREFIX_NAME)) {
-                    //On module page, checking for modules that contain a specific name with specific date, key event
-                    //e.g. list n/software dt/2022-05-04 ke/exam
-                    String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
-                    String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
-                    String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
-
-                    if (dateString.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
-                    }
-
-                    if (keyEvent.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
-                    }
-
-                    if (name.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
-                    }
-
-                    return new ListCommand(name, dateString, keyEvent.toUpperCase(),
-                        ListCommand.ListCommandType.MODULESWITHDATEANDKEYEVENTANDNAME);
-                }
-                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_DATETIME, CliSyntax.PREFIX_KEYEVENT)) {
-                    //On module page, checking for modules with specific date and key event
-                    //e.g. list dt/2022-05-04 ke/exam
-                    String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
-                    String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
-
-                    if (dateString.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
-                    }
-
-                    if (keyEvent.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
-                    }
-
-
-                    return new ListCommand(dateString, keyEvent.toUpperCase(),
-                        ListCommand.ListCommandType.MODULESWITHDATEANDKEYEVENT);
-                }
-                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_DATETIME)) {
-                    //On module page, checking for modules with specific name match and date time
-                    String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
-                    String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
-
-                    if (dateString.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
-                    }
-
-                    if (name.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
-                    }
-
-                    return new ListCommand(dateString, name,
-                        ListCommand.ListCommandType.MODULESWITHDATEANDNAME);
-                }
-                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_KEYEVENT)) {
-                    //On module page, checking for modules with specific name match and key event
-                    String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
-                    String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
-
-                    if (name.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
-                    }
-
-                    if (keyEvent.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
-                    }
-
-
-                    return new ListCommand(name, keyEvent,
-                        ListCommand.ListCommandType.MODULESWITHNAMEANDKEYEVENT);
-
-                }
-                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
-                    //Listing types of people on people page
-                    //e.g. list type/professors
-                    String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
-
-                    if (type.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Type"));
-                    }
-
-
-                    if (!(type.equals("professors") || type.equals("students"))) {
-                        //invalid type argument
-                        throw new ParseException(
-                            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, Messages.MESSAGE_WRONG_TYPE));
-                    }
-
-                    return new ListCommand(type, ListCommand.ListCommandType.TYPE);
-                } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_GROUP)) {
-                    //Group prefix present without option field (Listing groups from group page)
-                    String group = argMultimap.getValue(CliSyntax.PREFIX_GROUP).get().toLowerCase();
-
-                    if (group.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Group"));
-                    }
-
-                    if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
-                        //list g/W16-1 m/module
-                        String module = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toLowerCase();
-
-                        if (!ModuleCode.isValidModuleCode(module)) {
-                            throw new ParseException("Module Codes should only contain alphanumeric characters.");
-                        }
-
-                        if (module.strip().isEmpty()) {
-                            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
-                        }
-
-
-                        return new ListCommand(group, module, ListCommand.ListCommandType.SPECIFICGROUPFROMGROUPVIEW);
-                    }
-
-                    //e.g. list g/W16-1
-                    return new ListCommand(group, ListCommand.ListCommandType.GROUPFROMGROUPVIEW);
-                } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MEETINGTIME)) {
-                    //Find all groups with given meeting time on group page
-                    //e.g. list mt/<YYYY-MM-DD>
-
-                    String dateString = argMultimap.getValue(CliSyntax.PREFIX_MEETINGTIME).get();
-
-                    if (dateString.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Meeting"));
-                    }
-
-                    return new ListCommand(dateString, ListCommand.ListCommandType.GROUPWITHMEETINGDATE);
-                } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_DATETIME)) {
-                    String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
-
-                    if (dateString.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
-                    }
-
-                    return new ListCommand(dateString, ListCommand.ListCommandType.MODULESWITHEVENTDATE);
-                } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_KEYEVENT)) {
-                    //Listing modules that contain the given key event
-                    //e.g. list ke/exam, list ke/quiz
-                    String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
-
-                    if (keyEvent.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
-                    }
-
-                    return new ListCommand(keyEvent, ListCommand.ListCommandType.MODULESWITHKEYEVENT);
-                } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME)) {
-                    //Listing modules that contain the given name on module page
-                    // e.g. list n/software, list n/operating systems
-                    // Name only
-                    String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
-
-                    if (name.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
-                    }
-
-                    return new ListCommand(name, ListCommand.ListCommandType.MODULEWITHNAMEMATCH);
-                } else if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
-                    //listing module code in module view
-                    String moduleCode = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
-
-                    if (moduleCode.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
-                    }
-
-                    if (!ModuleCode.isValidModuleCode(moduleCode)) {
-                        throw new ParseException("Module Codes should only contain alphanumeric characters.");
-                    }
-
-                    return new ListCommand(moduleCode, ListCommand.ListCommandType.MODULE);
-                } else {
-                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                        ListCommand.MESSAGE_USAGE));
-                }
-            }
-            String option = argMultimap.getValue(CliSyntax.PREFIX_OPTION).get();
-            //Commands which have o/<OPTION> parameter.
-            switch (option) {
-            case "view":
-                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_VIEW)) {
-                    String view = argMultimap.getValue(CliSyntax.PREFIX_VIEW).get().toLowerCase();
-
-                    if (view.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "View"));
-                    }
-
-                    if (view.equals("modules")) {
-                        //Change to module view
-                        return new ListCommand(ListCommand.ListView.MODULES, ListCommand.ListCommandType.VIEW);
-                    } else if (view.equals("people")) {
-                        //Change to people view
-                        return new ListCommand(ListCommand.ListView.PEOPLE, ListCommand.ListCommandType.VIEW);
-                    } else if (view.equals("groups")) {
-                        //Change to group view
-                        return new ListCommand(ListCommand.ListView.GROUPS, ListCommand.ListCommandType.VIEW);
-                    } else {
-                        //Invalid view argument given
-                        throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            Messages.MESSAGE_INVALID_VIEW));
-                    }
-                } else {
-                    //View type argument not present
-                    throw new ParseException(
-                        String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            Messages.MESSAGE_VIEW_FIELD_MISSING));
-                }
-            case "module":
-                if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
-                    //module argument not present
-                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                        Messages.MESSAGE_MODULE_FIELD_MISSING));
-                }
-                String moduleCode = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
-
-                if (moduleCode.strip().isEmpty()) {
-                    throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
-                }
-
-                if (!ModuleCode.isValidModuleCode(moduleCode)) {
-                    throw new ParseException("Module Codes should only contain alphanumeric characters.");
-                }
-
-                if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
-                    //list module with specific type, e.g. list o/module m/cs2103 ty/professors
-                    String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
-
-                    if (type.strip().isEmpty()) {
-                        throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Type"));
-                    }
-
-                    if (!(type.equals("professors") || type.equals("students"))) {
-                        throw new ParseException(
-                            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                                Messages.MESSAGE_WRONG_TYPE));
-                    }
-                    return new ListCommand(moduleCode, type, ListCommand.ListCommandType.MODULEANDTYPE);
-                } else {
-                    //list module with no specific type e.g. list o/module m/cs2103 (in people page)
-
-                    if (!ModuleCode.isValidModuleCode(moduleCode)) {
-                        throw new ParseException("Module Codes should only contain alphanumeric characters.");
-                    }
-
-                    return new ListCommand(moduleCode, ListCommand.ListCommandType.MODULE);
-                }
-            case "group":
-
-                if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_GROUP)) {
-                    throw new ParseException(
-                        String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            Messages.MESSAGE_GROUP_FIELD_MISSING));
-                }
-                String group = argMultimap.getValue(CliSyntax.PREFIX_GROUP).get().toLowerCase();
-
-                if (group.strip().isEmpty()) {
-                    throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Group"));
-                }
-
-                if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
-                    //Module page listing group
-                    return new ListCommand(group, ListCommand.ListCommandType.GROUPFROMMODULEVIEW);
-                }
-                //People page listing group in a specific module
-                //e.g. list o/group m/cs2103 g/w16-1
-                String module = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
-
-                if (module.strip().isEmpty()) {
-                    throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
-                }
-
-                return new ListCommand(group, module, ListCommand.ListCommandType.PEOPLEINGROUP);
-
-            default:
-                throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                    Messages.MESSAGE_INVALID_LIST_OPTION));
-
-            }
-        } catch (ParseException pe) {
-            throw pe;
+        //List all (empty list command)
+        if (args.strip().equals("")) {
+            return new ListCommand();
         }
 
+        //List command that does not have o/OPTION
+        if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_OPTION)) {
+            return parseNoOption(argMultimap);
+        }
+
+        String option = argMultimap.getValue(CliSyntax.PREFIX_OPTION).get();
+
+        if (option.strip().isEmpty()) {
+            //The o/OPTION field cannot be blank.
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Option"));
+        }
+
+        //List command that has o/OPTION
+        switch (option) {
+        case "view":
+            return viewOption(argMultimap);
+        case "module":
+            return moduleOption(argMultimap);
+        case "group":
+            return groupOption(argMultimap);
+        default:
+            //The o/OPTION field is invalid.
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                Messages.MESSAGE_INVALID_LIST_OPTION));
+        }
+    }
+
+    //Helper methods for commands without o/OPTION
+    private static ListCommand dateTimeAndEventAndNamePresent(ArgumentMultimap argMultimap) throws ParseException {
+        //On module page, checking for modules that contain a specific name with specific date, key event
+        //e.g. list n/software dt/2022-05-04 ke/exam
+        String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
+        String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
+        String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
+
+        if (dateString.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+        }
+
+        if (keyEvent.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+        }
+
+        if (name.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+        }
+
+        return new ListCommand(name, dateString, keyEvent.toUpperCase(),
+                ListCommand.ListCommandType.MODULESWITHDATEANDKEYEVENTANDNAME);
+    }
+
+    private static ListCommand dateTimeAndEventPresent(ArgumentMultimap argMultimap) throws ParseException {
+        //On module page, checking for modules with specific date and key event
+        //e.g. list dt/2022-05-04 ke/exam
+        String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
+        String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
+
+        if (dateString.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+        }
+
+        if (keyEvent.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+        }
+
+        return new ListCommand(dateString, keyEvent.toUpperCase(),
+                ListCommand.ListCommandType.MODULESWITHDATEANDKEYEVENT);
+    }
+
+    private static ListCommand nameAndDateTimePresent(ArgumentMultimap argMultimap) throws ParseException {
+        //On module page, checking for modules with specific name match and date time
+        String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
+        String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
+
+        if (dateString.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+        }
+
+        if (name.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+        }
+
+        return new ListCommand(dateString, name,
+                ListCommand.ListCommandType.MODULESWITHDATEANDNAME);
+    }
+
+    private static ListCommand nameAndEventPresent(ArgumentMultimap argMultimap) throws ParseException {
+        //On module page, checking for modules with specific name match and key event
+        String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
+        String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
+
+        if (name.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+        }
+
+        if (keyEvent.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+        }
+
+
+        return new ListCommand(name, keyEvent,
+                ListCommand.ListCommandType.MODULESWITHNAMEANDKEYEVENT);
+    }
+
+    private static ListCommand typePresent(ArgumentMultimap argMultimap) throws ParseException {
+        //Listing types of people on people page
+        //e.g. list type/professors
+        String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
+
+        if (type.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Type"));
+        }
+
+
+        if (!(type.equals("professors") || type.equals("students"))) {
+            //invalid type argument
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, Messages.MESSAGE_WRONG_TYPE));
+        }
+
+        return new ListCommand(type, ListCommand.ListCommandType.TYPE);
+    }
+
+    private static ListCommand groupPresent(ArgumentMultimap argMultimap) throws ParseException {
+        //Group prefix present without option field (Listing groups from group page)
+        String group = argMultimap.getValue(CliSyntax.PREFIX_GROUP).get().toLowerCase();
+
+        if (group.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Group"));
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
+            //list g/W16-1 m/module
+            String module = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toLowerCase();
+
+            if (!ModuleCode.isValidModuleCode(module)) {
+                throw new ParseException(Messages.MESSAGE_INVALID_MODULE_CODE);
+            }
+
+            if (module.strip().isEmpty()) {
+                throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+            }
+
+
+            return new ListCommand(group, module, ListCommand.ListCommandType.SPECIFICGROUPFROMGROUPVIEW);
+        }
+
+        //e.g. list g/W16-1
+        return new ListCommand(group, ListCommand.ListCommandType.GROUPFROMGROUPVIEW);
+    }
+
+    private static ListCommand meetingPresent(ArgumentMultimap argMultimap) throws ParseException {
+        //Find all groups with given meeting time on group page
+        //e.g. list mt/<YYYY-MM-DD>
+
+        String dateString = argMultimap.getValue(CliSyntax.PREFIX_MEETINGTIME).get();
+
+        if (dateString.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Meeting"));
+        }
+
+        return new ListCommand(dateString, ListCommand.ListCommandType.GROUPWITHMEETINGDATE);
+    }
+
+    private static ListCommand datePresent(ArgumentMultimap argMultimap) throws ParseException {
+        String dateString = argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get();
+
+        if (dateString.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Date"));
+        }
+
+        return new ListCommand(dateString, ListCommand.ListCommandType.MODULESWITHEVENTDATE);
+    }
+
+    private static ListCommand eventPresent(ArgumentMultimap argMultimap) throws ParseException {
+        //Listing modules that contain the given key event
+        //e.g. list ke/exam, list ke/quiz
+        String keyEvent = argMultimap.getValue(CliSyntax.PREFIX_KEYEVENT).get();
+
+        if (keyEvent.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Key Event"));
+        }
+
+        return new ListCommand(keyEvent, ListCommand.ListCommandType.MODULESWITHKEYEVENT);
+    }
+
+    private static ListCommand namePresent(ArgumentMultimap argMultimap) throws ParseException {
+        //Listing modules that contain the given name on module page
+        // e.g. list n/software, list n/operating systems
+        // Name only
+        String name = argMultimap.getValue(CliSyntax.PREFIX_NAME).get();
+
+        if (name.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Name"));
+        }
+
+        return new ListCommand(name, ListCommand.ListCommandType.MODULEWITHNAMEMATCH);
+    }
+
+    private static ListCommand modulePresent(ArgumentMultimap argMultimap) throws ParseException {
+        //listing module code in module view
+        String moduleCode = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
+
+        if (moduleCode.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+        }
+
+        if (!ModuleCode.isValidModuleCode(moduleCode)) {
+            throw new ParseException(Messages.MESSAGE_INVALID_MODULE_CODE);
+        }
+
+        return new ListCommand(moduleCode, ListCommand.ListCommandType.MODULE);
+    }
+
+
+
+    private static ListCommand parseNoOption(ArgumentMultimap argMultimap) throws ParseException {
+        //Commands that have no option field
+        //Very specific command chain with 2-3 arguments
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_DATETIME, CliSyntax.PREFIX_KEYEVENT,
+                CliSyntax.PREFIX_NAME)) {
+            return dateTimeAndEventAndNamePresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_DATETIME, CliSyntax.PREFIX_KEYEVENT)) {
+            return dateTimeAndEventPresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_DATETIME)) {
+            return nameAndDateTimePresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_KEYEVENT)) {
+            return nameAndEventPresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
+            return typePresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_GROUP)) {
+            return groupPresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MEETINGTIME)) {
+            return meetingPresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_DATETIME)) {
+            return datePresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_KEYEVENT)) {
+            return eventPresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME)) {
+            return namePresent(argMultimap);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
+            return modulePresent(argMultimap);
+        }
+
+        throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                ListCommand.MESSAGE_USAGE));
+    }
+
+    //Helper methods for commands with o/OPTION field
+    private static ListCommand viewOption(ArgumentMultimap argMultimap) throws ParseException {
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_VIEW)) {
+            String view = argMultimap.getValue(CliSyntax.PREFIX_VIEW).get().toLowerCase();
+
+            if (view.strip().isEmpty()) {
+                throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "View"));
+            }
+
+            if (view.equals("modules")) {
+                //Change to module view
+                return new ListCommand(ListCommand.ListView.MODULES, ListCommand.ListCommandType.VIEW);
+            } else if (view.equals("people")) {
+                //Change to people view
+                return new ListCommand(ListCommand.ListView.PEOPLE, ListCommand.ListCommandType.VIEW);
+            } else if (view.equals("groups")) {
+                //Change to group view
+                return new ListCommand(ListCommand.ListView.GROUPS, ListCommand.ListCommandType.VIEW);
+            } else {
+                //Invalid view argument given
+                throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                        Messages.MESSAGE_INVALID_VIEW));
+            }
+        } else {
+            //View type argument not present
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            Messages.MESSAGE_VIEW_FIELD_MISSING));
+        }
+    }
+
+    private static ListCommand moduleOption(ArgumentMultimap argMultimap) throws ParseException {
+        if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
+            //module argument not present
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    Messages.MESSAGE_MODULE_FIELD_MISSING));
+        }
+        String moduleCode = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
+
+        if (moduleCode.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+        }
+
+        if (!ModuleCode.isValidModuleCode(moduleCode)) {
+            throw new ParseException(Messages.MESSAGE_INVALID_MODULE_CODE);
+        }
+
+        if (arePrefixesPresent(argMultimap, CliSyntax.PREFIX_TYPE)) {
+            //list module with specific type, e.g. list o/module m/cs2103 ty/professors
+            String type = argMultimap.getValue(CliSyntax.PREFIX_TYPE).get().toLowerCase();
+
+            if (type.strip().isEmpty()) {
+                throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Type"));
+            }
+
+            if (!(type.equals("professors") || type.equals("students"))) {
+                throw new ParseException(
+                        String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                                Messages.MESSAGE_WRONG_TYPE));
+            }
+            return new ListCommand(moduleCode, type, ListCommand.ListCommandType.MODULEANDTYPE);
+        } else {
+            //list module with no specific type e.g. list o/module m/cs2103 (in people page)
+
+            if (!ModuleCode.isValidModuleCode(moduleCode)) {
+                throw new ParseException(Messages.MESSAGE_INVALID_MODULE_CODE);
+            }
+
+            return new ListCommand(moduleCode, ListCommand.ListCommandType.MODULE);
+        }
+    }
+
+    private static ListCommand groupOption(ArgumentMultimap argMultimap) throws ParseException {
+        if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_GROUP)) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            Messages.MESSAGE_GROUP_FIELD_MISSING));
+        }
+        String group = argMultimap.getValue(CliSyntax.PREFIX_GROUP).get().toLowerCase();
+
+        if (group.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Group"));
+        }
+
+        if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_MODULE)) {
+            //Module page listing group
+            return new ListCommand(group, ListCommand.ListCommandType.GROUPFROMMODULEVIEW);
+        }
+        //People page listing group in a specific module
+        //e.g. list o/group m/cs2103 g/w16-1
+        String module = argMultimap.getValue(CliSyntax.PREFIX_MODULE).get().toUpperCase();
+
+        if (module.strip().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_FIELD_EMPTY, "Module"));
+        }
+
+        return new ListCommand(group, module, ListCommand.ListCommandType.PEOPLEINGROUP);
     }
 
 }

--- a/src/main/java/unibook/logic/parser/ParserUtil.java
+++ b/src/main/java/unibook/logic/parser/ParserUtil.java
@@ -327,7 +327,8 @@ public class ParserUtil {
     public static LocalDate parseDate(String date) throws ParseException {
         requireNonNull(date);
         String trimmedDate = date.trim();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd")
+                .withResolverStyle(ResolverStyle.STRICT);
         try {
             return LocalDate.parse(trimmedDate, formatter);
         } catch (Exception e) {

--- a/src/main/java/unibook/model/module/ModuleName.java
+++ b/src/main/java/unibook/model/module/ModuleName.java
@@ -16,7 +16,7 @@ public class ModuleName {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     public final String moduleName;
 

--- a/src/main/java/unibook/model/module/ModuleName.java
+++ b/src/main/java/unibook/model/module/ModuleName.java
@@ -9,7 +9,8 @@ import static unibook.commons.util.AppUtil.checkArgument;
 public class ModuleName {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            " Module Names "
+                    + "should only contain up to 50 alphabetical characters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -34,7 +35,7 @@ public class ModuleName {
      * Returns true if a given string is a valid module name.
      */
     public static boolean isValidModuleName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.length() <= 50;
     }
 
 

--- a/src/test/java/unibook/logic/commands/ListCommandTest.java
+++ b/src/test/java/unibook/logic/commands/ListCommandTest.java
@@ -1,37 +1,39 @@
-//package unibook.logic.commands;
-//
-//import static unibook.logic.commands.CommandTestUtil.assertCommandSuccess;
-//import static unibook.logic.commands.CommandTestUtil.showPersonAtIndex;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//
-//import unibook.model.Model;
-//import unibook.model.ModelManager;
-//import unibook.model.UserPrefs;
-//
-///**
-// * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
-// */
-//public class ListCommandTest {
-//
-//    private Model model;
-//    private Model expectedModel;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        model = new ModelManager(TypicalPersons.getTypicalUniBook(), new UserPrefs());
-//        expectedModel = new ModelManager(model.getUniBook(), new UserPrefs());
-//    }
-//
-//    @Test
-//    public void execute_listIsNotFiltered_showsSameList() {
-//        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-//    }
-//
-//    @Test
-//    public void execute_listIsFiltered_showsEverything() {
-//        showPersonAtIndex(model, TypicalIndexes.INDEX_FIRST_PERSON);
-//        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-//    }
-//}
+package unibook.logic.commands;
+
+import static unibook.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static unibook.logic.commands.CommandTestUtil.showPersonAtIndex;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import unibook.model.Model;
+import unibook.model.ModelManager;
+import unibook.model.UserPrefs;
+import unibook.testutil.typicalclasses.TypicalIndexes;
+import unibook.testutil.typicalclasses.TypicalUniBook;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(TypicalUniBook.getTypicalUniBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getUniBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showPersonAtIndex(model, TypicalIndexes.INDEX_FIRST_PERSON);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/unibook/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/unibook/logic/parser/ListCommandParserTest.java
@@ -1,0 +1,119 @@
+package unibook.logic.parser;
+
+import org.junit.jupiter.api.Test;
+
+import unibook.logic.commands.ListCommand;
+import unibook.logic.commands.ListCommand.ListCommandType;
+import unibook.logic.commands.ListCommand.ListView;
+
+public class ListCommandParserTest {
+
+    private ListCommandParser parser = new ListCommandParser();
+
+    @Test
+    public void viewChange_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list o/view v/groups",
+                new ListCommand(ListView.GROUPS, ListCommandType.VIEW));
+    }
+
+    //Tests for parsing commands for "People view"
+    @Test
+    public void people_listSpecificType_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list type/professors",
+                new ListCommand("professors", ListCommandType.TYPE));
+    }
+
+    @Test
+    public void people_listModuleAndCode_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list o/module m/CS2103",
+                new ListCommand("CS2103", ListCommandType.MODULE));
+    }
+
+    @Test
+    public void people_listModuleAndCodeAndType_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list o/module m/CS2103 type/students",
+                new ListCommand("CS2103", "students", ListCommandType.MODULEANDTYPE));
+    }
+
+    @Test
+    public void people_listGroupAndModuleCodeAndGroupName_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list o/group m/CS2103 g/W16-1",
+                new ListCommand("w16-1", "CS2103", ListCommandType.PEOPLEINGROUP));
+    }
+
+    //Tests for parsing commands for "Modules" view
+    @Test
+    public void modules_moduleCode_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list m/CS2103",
+                new ListCommand("CS2103", ListCommandType.MODULE));
+    }
+
+    @Test
+    public void modules_name_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list n/Software",
+                new ListCommand("Software", ListCommandType.MODULEWITHNAMEMATCH));
+    }
+
+    @Test
+    public void modules_keyEvent_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list ke/EXAM",
+                new ListCommand("EXAM", ListCommandType.MODULESWITHKEYEVENT));
+    }
+
+    @Test
+    public void modules_date_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list dt/2022-05-04",
+                new ListCommand("2022-05-04", ListCommandType.MODULESWITHEVENTDATE));
+    }
+
+    @Test
+    public void modules_dateAndKeyEvent_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list dt/2022-05-04 ke/ASSIGNMENT_DUE",
+                new ListCommand("2022-05-04", "ASSIGNMENT_DUE", ListCommandType.MODULESWITHDATEANDKEYEVENT));
+    }
+
+    @Test
+    public void modules_dateAndName_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list dt/2022-05-04 n/Network",
+                new ListCommand("2022-05-04", "Network", ListCommandType.MODULESWITHDATEANDNAME));
+    }
+
+    @Test
+    public void modules_nameAndKeyEvent_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list n/Network ke/ASSIGNMENT_DUE",
+                new ListCommand("Network", "ASSIGNMENT_DUE", ListCommandType.MODULESWITHNAMEANDKEYEVENT));
+    }
+
+    @Test
+    public void modules_nameAndKeyEventAndDate_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list n/Network ke/ASSIGNMENT_DUE dt/2022-05-04",
+                new ListCommand("Network", "2022-05-04", "ASSIGNMENT_DUE",
+                        ListCommandType.MODULESWITHDATEANDKEYEVENTANDNAME));
+    }
+
+    @Test
+    public void modules_groupAndGroupName_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list o/group g/w16-1",
+                new ListCommand("w16-1", ListCommandType.GROUPFROMMODULEVIEW));
+    }
+
+    //Tests for parsing commands for "Groups" view
+    @Test
+    public void groups_groupName_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list g/w16-1",
+                new ListCommand("w16-1", ListCommandType.GROUPFROMGROUPVIEW));
+    }
+
+    @Test
+    public void groups_groupNameAndModuleCode_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list g/w16-1 m/CS2107",
+                new ListCommand("w16-1", "CS2107", ListCommandType.SPECIFICGROUPFROMGROUPVIEW));
+    }
+
+    @Test
+    public void groups_meeting_returnsCorrectCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "list mt/2022-04-03",
+                new ListCommand("2022-04-03", ListCommandType.GROUPWITHMEETINGDATE));
+    }
+
+}


### PR DESCRIPTION
Refactor `ListCommand` and `ListCommandParser` to make it more SLAP and reader-friendly.

Added some tests for `ListCommandParser.java`, fixed some bugs mentioned in PE-Dryrun.

note that as a new restriction `ModuleCode` can only have 1-10 alphanumeric characters and `ModuleName` can only have 1-50 alphabetic characters to prevent long/invalid inputs from breaking the app.

Todo:
More documentation
Refine UG
Add tests for Module and ListCommand
