### PR TITLE
Update Add Command to allow persons of the same name to be added

### DIFF
--- a/src/main/java/unibook/logic/commands/AddCommand.java
+++ b/src/main/java/unibook/logic/commands/AddCommand.java
@@ -225,6 +225,9 @@ public class AddCommand extends Command {
         + " does not exist in the UniBook";
     public static final String MESSAGE_GROUP_DOES_NOT_EXIST = "One or more of the groups entered"
         + " does not exist in the UniBook";
+    private static final String MESSAGE_DUPLICATE_PHONE_AND_EMAIL = "The phone number or email entered already belongs"
+            + " to an existing person in the UniBook.\nPlease ensure that the phone number or"
+            + " email for each person is unique!";
 
     private Person personToAdd;
     private Module moduleToAdd;
@@ -328,8 +331,8 @@ public class AddCommand extends Command {
             model.addModule(moduleToAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS_MODULE, moduleToAdd));
         } else if (personToAdd != null) {
-            if (model.hasPerson(personToAdd)) {
-                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            if (model.hasPersonWithPhoneOrEmail(personToAdd)) {
+                throw new CommandException(MESSAGE_DUPLICATE_PHONE_AND_EMAIL);
             } else if (!model.isModuleExist(moduleCodeSet)) {
                 throw new CommandException(MESSAGE_MODULE_DOES_NOT_EXIST);
             }

--- a/src/main/java/unibook/model/Model.java
+++ b/src/main/java/unibook/model/Model.java
@@ -74,6 +74,11 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a person with the same phone or email as {@code person} exists in the UniBook.
+     */
+    boolean hasPersonWithPhoneOrEmail(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in the UniBook.
      */

--- a/src/main/java/unibook/model/ModelManager.java
+++ b/src/main/java/unibook/model/ModelManager.java
@@ -107,6 +107,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPersonWithPhoneOrEmail(Person person) {
+        requireNonNull(person);
+        return uniBook.phoneNumberBeingUsed(person.getPhone()) || uniBook.emailBeingUsed(person.getEmail());
+    }
+
+    @Override
     public void deletePerson(Person target) {
         uniBook.removePerson(target);
     }

--- a/src/main/java/unibook/model/module/Module.java
+++ b/src/main/java/unibook/model/module/Module.java
@@ -270,7 +270,7 @@ public class Module {
      */
     public void addStudent(Student s) {
         requireNonNull(s);
-        if (students.contains(s)) {
+        if (students.stream().anyMatch(s::hasSameEmailOrPhone)) {
             throw new DuplicatePersonException();
         }
         students.add(s);
@@ -283,7 +283,7 @@ public class Module {
      */
     public void addProfessor(Professor p) {
         requireNonNull(p);
-        if (professors.contains(p)) {
+        if (professors.stream().anyMatch(p::hasSameEmailOrPhone)) {
             throw new DuplicatePersonException();
         }
         professors.add(p);

--- a/src/main/java/unibook/model/person/UniquePersonList.java
+++ b/src/main/java/unibook/model/person/UniquePersonList.java
@@ -200,6 +200,9 @@ public class UniquePersonList implements Iterable<Person> {
      * Returns true if {@code persons} contains person with given phone number.
      */
     public boolean phoneNumberBeingUsed(Phone phone) {
+        if (phone.isEmpty()) {
+            return false;
+        }
         for (int i = 0; i < internalList.size(); i++) {
             if (internalList.get(i).getPhone().equals(phone)) {
                 return true;
@@ -213,6 +216,9 @@ public class UniquePersonList implements Iterable<Person> {
      * Returns true if {@code persons} contains person with given email.
      */
     public boolean emailBeingUsed(Email email) {
+        if (email.isEmpty()) {
+            return false;
+        }
         for (int i = 0; i < internalList.size(); i++) {
             if (internalList.get(i).getEmail().equals(email)) {
                 return true;

--- a/src/test/java/unibook/logic/commands/AddCommandTest.java
+++ b/src/test/java/unibook/logic/commands/AddCommandTest.java
@@ -138,6 +138,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasPersonWithPhoneOrEmail(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Users can now add persons of the same name, as long as the phone and email does not already exist in the UniBook.